### PR TITLE
Fix mermaid diagrams not rendering as images on initial load

### DIFF
--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -175,6 +175,13 @@ impl App {
             }
         }
 
+        // Reparse with mermaid-as-images now that the picker is configured.
+        // The initial parse used mermaid_as_images=false (before the picker
+        // was available), so mermaid blocks are still code blocks.
+        if model.should_render_mermaid_as_images() {
+            model.reflow_layout();
+        }
+
         // Pre-load images from the document
         let images_scope = crate::perf::scope("app.load_nearby_images.initial");
         model.load_nearby_images();


### PR DESCRIPTION
### PR Summary

Markless renders mermaid diagrams as inline images using `mermaid-rs-renderer` (a pure Rust mermaid implementation) to generate SVG, then `resvg` to rasterize it — no external `mmdc` CLI or Node.js needed.

For this to work, the markdown parser needs to know upfront that mermaid code blocks should be treated as image placeholders rather than regular code blocks (controlled by the `mermaid_as_images` flag). This flag is only true when the terminal supports a real graphics protocol (Kitty, Sixel, iTerm2) determined by the image picker.

The bug: the initial document parse in `event_loop.rs` happens *before* the image picker is configured on the model, so `mermaid_as_images` is always  `false` during the first parse. Mermaid blocks get rendered as plain code blocks. Later, `load_nearby_images()` iterates the document's image list — but it's empty (no mermaid images were registered), so no reparse is ever triggered.

  The fix: after the model is fully configured with the picker, call `reflow_layout()` which reparses the document with `mermaid_as_images=true`, converting mermaid code blocks into image placeholders that the rendering pipeline can then rasterize.
