### PR TITLE
Fix TOC selection during watched reloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "markless"
-version = "0.9.24"
+version = "0.9.25"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markless"
-version = "0.9.24"
+version = "0.9.25"
 edition = "2024"
 authors = ["Josh V"]
 description = "A terminal markdown viewer with image support"

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -10,7 +10,7 @@ use ratatui_image::picker::{Picker, ProtocolType};
 use crate::config::ImageMode;
 use ratatui_image::protocol::StatefulProtocol;
 
-use crate::document::Document;
+use crate::document::{Document, HeadingRef};
 use crate::editor::EditorBuffer;
 use crate::image::ImageLoader;
 use crate::ui::viewport::Viewport;
@@ -549,6 +549,48 @@ impl Model {
             .saturating_sub(self.toc_visible_rows())
     }
 
+    pub(super) fn clamp_toc_to_heading_bounds(&mut self) {
+        let Some(max_heading_idx) = self.document.headings().len().checked_sub(1) else {
+            self.toc_selected = None;
+            self.toc_scroll_offset = 0;
+            return;
+        };
+
+        if let Some(selected) = self.toc_selected {
+            self.toc_selected = Some(selected.min(max_heading_idx));
+        }
+        self.toc_scroll_offset = self.toc_scroll_offset.min(self.max_toc_scroll_offset());
+    }
+
+    pub(super) fn restore_focused_toc_selection(&mut self, old_selected: Option<&HeadingRef>) {
+        let headings = self.document.headings();
+        if headings.is_empty() {
+            self.toc_selected = None;
+            self.toc_scroll_offset = 0;
+            return;
+        }
+
+        let selected = old_selected
+            .and_then(|old| {
+                old.id.as_ref().and_then(|old_id| {
+                    headings
+                        .iter()
+                        .position(|heading| heading.id.as_ref() == Some(old_id))
+                })
+            })
+            .or_else(|| {
+                old_selected.and_then(|old| {
+                    headings
+                        .iter()
+                        .position(|heading| heading.level == old.level && heading.text == old.text)
+                })
+            })
+            .unwrap_or(0);
+
+        self.toc_selected = Some(selected);
+        self.toc_scroll_offset = selected.min(self.max_toc_scroll_offset());
+    }
+
     pub(super) fn sync_toc_to_viewport(&mut self) {
         let Some(selected) =
             closest_heading_to_line(self.document.headings(), self.viewport.offset())
@@ -809,6 +851,13 @@ impl Model {
     }
 
     pub(super) fn reload_from_disk(&mut self) -> Result<()> {
+        let old_selected_heading = if !self.browse_mode && self.toc_focused {
+            self.toc_selected
+                .and_then(|selected| self.document.headings().get(selected))
+                .cloned()
+        } else {
+            None
+        };
         let old_mermaid_sources = self.document.mermaid_sources().clone();
         let old_math_sources = self.document.math_sources().clone();
         let raw_bytes = std::fs::read(&self.file_path)?;
@@ -837,6 +886,13 @@ impl Model {
             .retain(|src, _| valid_images.contains(src));
 
         self.viewport.set_total_lines(self.document.line_count());
+        if !self.browse_mode {
+            if self.toc_focused {
+                self.restore_focused_toc_selection(old_selected_heading.as_ref());
+            } else {
+                self.clamp_toc_to_heading_bounds();
+            }
+        }
         self.toc_scroll_offset = self.toc_scroll_offset.min(self.max_toc_scroll_offset());
         let allow_short = self.search_allow_short;
         refresh_search_matches(self, false, allow_short);

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3055,6 +3055,65 @@ fn test_file_changed_shows_reload_toast() {
 }
 
 #[test]
+fn test_file_changed_falls_back_to_top_when_selected_heading_disappears() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().canonicalize().unwrap().join("test.md");
+    let initial = "# One\n\nalpha\n\n# Two\n\nbeta\n\n# Three\n\ngamma\n\n# Four\n\ndelta\n";
+    std::fs::write(&file_path, initial).unwrap();
+
+    let doc = Document::parse_with_layout(initial, 80).unwrap();
+    let mut model = Model::new(file_path.clone(), doc, (80, 8));
+    model.file_path = file_path.clone();
+    model.toc_visible = true;
+    model.toc_focused = true;
+    model.toc_selected = Some(model.document.headings().len() - 1);
+
+    let updated = "# One\n\nalpha\n\n# Two\n\nbeta\n";
+    std::fs::write(&file_path, updated).unwrap();
+
+    let mut watcher = None;
+    let mut model = update(model, Message::FileChanged);
+    App::handle_message_side_effects(&mut model, &mut watcher, &Message::FileChanged);
+
+    assert_eq!(model.document.headings().len(), 2);
+    assert_eq!(
+        model.toc_selected,
+        Some(0),
+        "reloading should reset to the top TOC entry when the selected heading is gone"
+    );
+}
+
+#[test]
+fn test_file_changed_preserves_manual_toc_selection_when_focused() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().canonicalize().unwrap().join("test.md");
+    let initial = "# One\n\nalpha\n\n# Two\n\nbeta\n\n# Three\n\ngamma\n\n# Four\n\ndelta\n";
+    std::fs::write(&file_path, initial).unwrap();
+
+    let doc = Document::parse_with_layout(initial, 80).unwrap();
+    let mut model = Model::new(file_path.clone(), doc, (80, 8));
+    model.file_path = file_path.clone();
+    model.toc_visible = true;
+    model.toc_focused = true;
+    model.viewport.go_to_top();
+    model.toc_selected = Some(3);
+
+    let updated = "# One\n\nalpha updated\n\n# Two\n\nbeta\n\n# Three\n\ngamma\n\n# Four\n\ndelta\n";
+    std::fs::write(&file_path, updated).unwrap();
+
+    let mut watcher = None;
+    let mut model = update(model, Message::FileChanged);
+    App::handle_message_side_effects(&mut model, &mut watcher, &Message::FileChanged);
+
+    assert_eq!(model.document.headings().len(), 4);
+    assert_eq!(
+        model.toc_selected,
+        Some(3),
+        "focused TOC selection should survive reload instead of snapping back to the viewport"
+    );
+}
+
+#[test]
 fn test_toggle_watch_watches_model_file_path_not_app_path() {
     let dir = tempdir().unwrap();
     let canonical_dir = dir.path().canonicalize().unwrap();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3098,7 +3098,8 @@ fn test_file_changed_preserves_manual_toc_selection_when_focused() {
     model.viewport.go_to_top();
     model.toc_selected = Some(3);
 
-    let updated = "# One\n\nalpha updated\n\n# Two\n\nbeta\n\n# Three\n\ngamma\n\n# Four\n\ndelta\n";
+    let updated =
+        "# One\n\nalpha updated\n\n# Two\n\nbeta\n\n# Three\n\ngamma\n\n# Four\n\ndelta\n";
     std::fs::write(&file_path, updated).unwrap();
 
     let mut watcher = None;

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -169,6 +169,8 @@ pub fn update(mut model: Model, msg: Message) -> Model {
             | Message::TocClick(_)
             | Message::TocCollapse
             | Message::TocExpand
+            | Message::FileChanged
+            | Message::ForceReload
             | Message::HoverLink(_)
     );
     // Reset confirmation flags on any action other than the confirmed one.


### PR DESCRIPTION
## Summary
- preserve the focused TOC selection across watched reloads when the same heading still exists
- reset to the top TOC entry when the selected heading disappears after reload
- skip generic viewport TOC auto-sync for FileChanged/ForceReload and cover the behavior with regression tests

## Testing
- cargo test

Closes #40