### PR TITLE
Add mouse selection toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md
+
+## Skills
+
+Available local skills for this repo:
+
+- `release`: Cut a release for markless. Runs checks, bumps version, commits and pushes, merges the PR, tags, and publishes to crates.io. File: `/workspace/.claude/skills/release/SKILL.md`
+
+## How To Use Skills
+
+- If the user asks for a release workflow, use the `release` skill.
+- Read the referenced `SKILL.md` and follow it directly.
+- Prefer the skill instructions over ad hoc release steps.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "markless"
-version = "0.9.25"
+version = "0.9.26"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markless"
-version = "0.9.25"
+version = "0.9.26"
 edition = "2024"
 authors = ["Josh V"]
 description = "A terminal markdown viewer with image support"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ When given a directory, markless opens in browse mode: the sidebar shows the fil
 ## Command Line Options
 
 - `--watch`  Auto-reload on file changes
+- `--no-mouse-select`  Disable markless mouse selection capture
+- `--mouse-select`  Re-enable markless mouse selection capture (overrides saved `--no-mouse-select`)
 - `--no-toc`  Hide the table of contents sidebar
 - `--toc`  Start with TOC visible
 - `--no-images`  Disable inline image rendering (show placeholders only)

--- a/src/app/effects.rs
+++ b/src/app/effects.rs
@@ -4,12 +4,13 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
 
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 
-use super::event_loop::set_mouse_capture;
+use super::event_loop::set_mouse_motion_tracking;
 
 use crate::app::{App, Message, Model, ToastLevel};
 use crate::config::shell_split_tokens;
@@ -447,7 +448,8 @@ impl App {
         let extra_args = tokens.get(1..).unwrap_or_default();
 
         // Suspend TUI: disable mouse, leave alternate screen, disable raw mode
-        let _ = set_mouse_capture(false);
+        let _ = set_mouse_motion_tracking(false);
+        let _ = execute!(stdout(), DisableMouseCapture);
         let _ = execute!(stdout(), LeaveAlternateScreen);
         let _ = disable_raw_mode();
 
@@ -460,7 +462,10 @@ impl App {
         // Restore TUI (always, even on error)
         let _ = enable_raw_mode();
         let _ = execute!(stdout(), EnterAlternateScreen);
-        let _ = set_mouse_capture(model.mouse_enabled);
+        if model.mouse_enabled {
+            let _ = execute!(stdout(), EnableMouseCapture);
+            let _ = set_mouse_motion_tracking(true);
+        }
         model.needs_full_redraw = true;
 
         match result {

--- a/src/app/effects.rs
+++ b/src/app/effects.rs
@@ -4,13 +4,12 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
 
-use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 
-use super::event_loop::set_mouse_motion_tracking;
+use super::event_loop::set_mouse_capture;
 
 use crate::app::{App, Message, Model, ToastLevel};
 use crate::config::shell_split_tokens;
@@ -448,8 +447,7 @@ impl App {
         let extra_args = tokens.get(1..).unwrap_or_default();
 
         // Suspend TUI: disable mouse, leave alternate screen, disable raw mode
-        let _ = set_mouse_motion_tracking(false);
-        let _ = execute!(stdout(), DisableMouseCapture);
+        let _ = set_mouse_capture(false);
         let _ = execute!(stdout(), LeaveAlternateScreen);
         let _ = disable_raw_mode();
 
@@ -462,8 +460,7 @@ impl App {
         // Restore TUI (always, even on error)
         let _ = enable_raw_mode();
         let _ = execute!(stdout(), EnterAlternateScreen);
-        let _ = execute!(stdout(), EnableMouseCapture);
-        let _ = set_mouse_motion_tracking(true);
+        let _ = set_mouse_capture(model.mouse_enabled);
         model.needs_full_redraw = true;
 
         match result {

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -1,4 +1,4 @@
-use std::io::stdout;
+use std::io::{Write, stdout};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -87,10 +87,6 @@ impl App {
     /// or the event loop encounters an I/O or parsing failure.
     pub fn run(&mut self) -> Result<()> {
         let _run_scope = crate::perf::scope("app.run.total");
-
-        // Clear any stale mouse reporting left behind by a previous run or tmux pane state
-        // before entering raw mode.
-        let _ = set_mouse_capture(false);
 
         // Create image picker BEFORE initializing terminal (queries stdio)
         let picker = if self.images_enabled {
@@ -199,7 +195,7 @@ impl App {
         let result = Self::event_loop(&mut terminal, &mut model);
 
         // Restore terminal
-        let _ = set_mouse_capture(false);
+        let _ = execute!(stdout(), DisableMouseCapture);
         ratatui::restore();
 
         result
@@ -292,7 +288,13 @@ impl App {
             }
             let should_enable_mouse = model.mouse_enabled;
             if should_enable_mouse != mouse_capture_enabled {
-                set_mouse_capture(should_enable_mouse)?;
+                if should_enable_mouse {
+                    execute!(stdout(), EnableMouseCapture)?;
+                    set_mouse_motion_tracking(true)?;
+                } else {
+                    set_mouse_motion_tracking(false)?;
+                    execute!(stdout(), DisableMouseCapture)?;
+                }
                 mouse_capture_enabled = should_enable_mouse;
             }
 
@@ -446,17 +448,21 @@ impl App {
             }
         }
         if mouse_capture_enabled {
-            let _ = set_mouse_capture(false);
+            let _ = set_mouse_motion_tracking(false);
+            let _ = execute!(stdout(), DisableMouseCapture);
         }
         Ok(())
     }
 }
 
-pub(super) fn set_mouse_capture(enable: bool) -> std::io::Result<()> {
+pub(super) fn set_mouse_motion_tracking(enable: bool) -> std::io::Result<()> {
+    // Request any-event mouse motion reporting (1003) with SGR encoding (1006).
+    // This improves hover support in terminals like Ghostty.
+    let mut out = stdout();
     if enable {
-        execute!(stdout(), EnableMouseCapture)?;
+        out.write_all(b"\x1b[?1003h\x1b[?1006h")?;
     } else {
-        execute!(stdout(), DisableMouseCapture)?;
+        out.write_all(b"\x1b[?1003l\x1b[?1006l")?;
     }
-    Ok(())
+    out.flush()
 }

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -1,4 +1,4 @@
-use std::io::{Write, stdout};
+use std::io::stdout;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -88,6 +88,10 @@ impl App {
     pub fn run(&mut self) -> Result<()> {
         let _run_scope = crate::perf::scope("app.run.total");
 
+        // Clear any stale mouse reporting left behind by a previous run or tmux pane state
+        // before entering raw mode.
+        let _ = set_mouse_capture(false);
+
         // Create image picker BEFORE initializing terminal (queries stdio)
         let picker = if self.images_enabled {
             let picker_scope = crate::perf::scope("app.create_picker");
@@ -146,6 +150,7 @@ impl App {
         let mut model =
             Model::new(effective_file, document, (size.width, size.height)).with_picker(picker);
         model.watch_enabled = self.watch_enabled;
+        model.mouse_enabled = self.mouse_enabled;
         model.toc_visible = toc_visible;
         model.image_mode = self.image_mode;
         model.images_enabled = self.images_enabled;
@@ -194,7 +199,7 @@ impl App {
         let result = Self::event_loop(&mut terminal, &mut model);
 
         // Restore terminal
-        let _ = execute!(stdout(), DisableMouseCapture);
+        let _ = set_mouse_capture(false);
         ratatui::restore();
 
         result
@@ -285,15 +290,9 @@ impl App {
                 }
                 watched_path.clone_from(&model.file_path);
             }
-            let should_enable_mouse = true;
+            let should_enable_mouse = model.mouse_enabled;
             if should_enable_mouse != mouse_capture_enabled {
-                if should_enable_mouse {
-                    execute!(stdout(), EnableMouseCapture)?;
-                    set_mouse_motion_tracking(true)?;
-                } else {
-                    set_mouse_motion_tracking(false)?;
-                    execute!(stdout(), DisableMouseCapture)?;
-                }
+                set_mouse_capture(should_enable_mouse)?;
                 mouse_capture_enabled = should_enable_mouse;
             }
 
@@ -447,21 +446,17 @@ impl App {
             }
         }
         if mouse_capture_enabled {
-            let _ = set_mouse_motion_tracking(false);
-            let _ = execute!(stdout(), DisableMouseCapture);
+            let _ = set_mouse_capture(false);
         }
         Ok(())
     }
 }
 
-pub(super) fn set_mouse_motion_tracking(enable: bool) -> std::io::Result<()> {
-    // Request any-event mouse motion reporting (1003) with SGR encoding (1006).
-    // This improves hover support in terminals like Ghostty.
-    let mut out = stdout();
+pub(super) fn set_mouse_capture(enable: bool) -> std::io::Result<()> {
     if enable {
-        out.write_all(b"\x1b[?1003h\x1b[?1006h")?;
+        execute!(stdout(), EnableMouseCapture)?;
     } else {
-        out.write_all(b"\x1b[?1003l\x1b[?1006l")?;
+        execute!(stdout(), DisableMouseCapture)?;
     }
-    out.flush()
+    Ok(())
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,6 +23,7 @@ use crate::config::ImageMode;
 pub struct App {
     file_path: PathBuf,
     watch_enabled: bool,
+    mouse_enabled: bool,
     toc_visible: bool,
     image_mode: Option<ImageMode>,
     images_enabled: bool,
@@ -40,6 +41,7 @@ impl App {
         Self {
             file_path,
             watch_enabled: false,
+            mouse_enabled: true,
             toc_visible: false,
             image_mode: None,
             images_enabled: true,
@@ -56,6 +58,13 @@ impl App {
     #[must_use]
     pub const fn with_watch(mut self, enabled: bool) -> Self {
         self.watch_enabled = enabled;
+        self
+    }
+
+    /// Enable or disable terminal mouse capture.
+    #[must_use]
+    pub const fn with_mouse_enabled(mut self, enabled: bool) -> Self {
+        self.mouse_enabled = enabled;
         self
     }
 

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -83,6 +83,8 @@ pub struct Model {
     pub toc_scroll_offset: usize,
     /// Whether file watching is enabled
     pub watch_enabled: bool,
+    /// Whether terminal mouse capture is enabled
+    pub mouse_enabled: bool,
     /// Global config path shown in help
     pub config_global_path: Option<PathBuf>,
     /// Local override path shown in help
@@ -200,6 +202,7 @@ impl Model {
             toc_selected: None,
             toc_scroll_offset: 0,
             watch_enabled: false,
+            mouse_enabled: true,
             config_global_path: None,
             config_local_path: None,
             help_visible: false,
@@ -990,6 +993,7 @@ impl Default for Model {
             toc_selected: None,
             toc_scroll_offset: 0,
             watch_enabled: false,
+            mouse_enabled: true,
             config_global_path: None,
             config_local_path: None,
             help_visible: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,8 @@ impl std::fmt::Display for ImageMode {
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ConfigFlags {
     pub watch: bool,
+    pub no_mouse_select: bool,
+    pub mouse_select: bool,
     pub no_toc: bool,
     pub toc: bool,
     pub no_images: bool,
@@ -61,6 +63,8 @@ impl ConfigFlags {
     pub fn union(&self, other: &Self) -> Self {
         Self {
             watch: self.watch || other.watch,
+            no_mouse_select: self.no_mouse_select || other.no_mouse_select,
+            mouse_select: self.mouse_select || other.mouse_select,
             no_toc: self.no_toc || other.no_toc,
             toc: self.toc || other.toc,
             no_images: self.no_images || other.no_images,
@@ -182,6 +186,9 @@ pub fn save_config_flags(path: &Path, flags: &ConfigFlags) -> Result<()> {
     if flags.watch {
         lines.push("--watch".to_string());
     }
+    if flags.no_mouse_select && !flags.mouse_select {
+        lines.push("--no-mouse-select".to_string());
+    }
     if flags.no_toc {
         lines.push("--no-toc".to_string());
     }
@@ -257,6 +264,10 @@ pub fn parse_flag_tokens(tokens: &[String]) -> ConfigFlags {
         let token = &tokens[i];
         if token == "--watch" {
             flags.watch = true;
+        } else if token == "--no-mouse-select" {
+            flags.no_mouse_select = true;
+        } else if token == "--mouse-select" {
+            flags.mouse_select = true;
         } else if token == "--no-toc" {
             flags.no_toc = true;
         } else if token == "--toc" {
@@ -344,6 +355,7 @@ mod tests {
         let args = vec![
             "markless".to_string(),
             "--watch".to_string(),
+            "--no-mouse-select".to_string(),
             "--toc".to_string(),
             "--no-images".to_string(),
             "--theme".to_string(),
@@ -354,6 +366,7 @@ mod tests {
         ];
         let flags = parse_flag_tokens(&args);
         assert!(flags.watch);
+        assert!(flags.no_mouse_select);
         assert!(flags.toc);
         assert!(flags.no_images);
         assert_eq!(flags.theme, Some(ThemeMode::Dark));
@@ -496,6 +509,70 @@ mod tests {
         assert!(merged.watch);
         assert!(merged.toc);
         assert_eq!(merged.theme, Some(ThemeMode::Dark));
+    }
+
+    #[test]
+    fn test_parse_flag_tokens_no_mouse_select() {
+        let args = vec!["--no-mouse-select".to_string()];
+        let flags = parse_flag_tokens(&args);
+        assert!(flags.no_mouse_select);
+    }
+
+    #[test]
+    fn test_parse_flag_tokens_mouse_select() {
+        let args = vec!["--mouse-select".to_string()];
+        let flags = parse_flag_tokens(&args);
+        assert!(flags.mouse_select);
+    }
+
+    #[test]
+    fn test_config_union_mouse_select_overrides_no_mouse_select() {
+        let file = ConfigFlags {
+            no_mouse_select: true,
+            ..ConfigFlags::default()
+        };
+        let cli = ConfigFlags {
+            mouse_select: true,
+            ..ConfigFlags::default()
+        };
+        let merged = file.union(&cli);
+        assert!(merged.no_mouse_select);
+        assert!(merged.mouse_select);
+    }
+
+    #[test]
+    fn test_save_load_no_mouse_select() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".marklessrc");
+        let flags = ConfigFlags {
+            no_mouse_select: true,
+            ..ConfigFlags::default()
+        };
+        save_config_flags(&path, &flags).unwrap();
+        let loaded = load_config_flags(&path).unwrap();
+        assert!(loaded.no_mouse_select);
+    }
+
+    #[test]
+    fn test_mouse_select_overrides_no_mouse_select_in_save() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(".marklessrc");
+        let flags = ConfigFlags {
+            no_mouse_select: true,
+            ..ConfigFlags::default()
+        };
+        save_config_flags(&path, &flags).unwrap();
+        let override_flags = ConfigFlags {
+            no_mouse_select: true,
+            mouse_select: true,
+            ..ConfigFlags::default()
+        };
+        save_config_flags(&path, &override_flags).unwrap();
+        let loaded = load_config_flags(&path).unwrap();
+        assert!(
+            !loaded.no_mouse_select,
+            "--mouse-select should prevent --no-mouse-select from being saved"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use crossterm::event::DisableMouseCapture;
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 
 use markless::app::App;
@@ -280,7 +279,6 @@ fn main() -> Result<()> {
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = disable_raw_mode();
-        let _ = crossterm::execute!(std::io::stderr(), DisableMouseCapture);
         let _ = crossterm::execute!(std::io::stderr(), crossterm::terminal::LeaveAlternateScreen);
         default_hook(info);
     }));

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use crossterm::event::DisableMouseCapture;
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 
 use markless::app::App;
@@ -37,6 +38,14 @@ struct Cli {
     /// Watch file for changes and auto-reload
     #[arg(short, long)]
     watch: bool,
+
+    /// Disable markless mouse selection capture
+    #[arg(long)]
+    no_mouse_select: bool,
+
+    /// Re-enable markless mouse selection capture (overrides saved --no-mouse-select)
+    #[arg(long, conflicts_with = "no_mouse_select")]
+    mouse_select: bool,
 
     /// Hide table of contents sidebar
     #[arg(long)]
@@ -271,6 +280,7 @@ fn main() -> Result<()> {
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = disable_raw_mode();
+        let _ = crossterm::execute!(std::io::stderr(), DisableMouseCapture);
         let _ = crossterm::execute!(std::io::stderr(), crossterm::terminal::LeaveAlternateScreen);
         default_hook(info);
     }));
@@ -344,6 +354,7 @@ fn main() -> Result<()> {
 
     let mut app = App::new(cli.path)
         .with_watch(effective.watch)
+        .with_mouse_enabled(effective.mouse_select || !effective.no_mouse_select)
         .with_toc_visible(effective.toc && !effective.no_toc)
         .with_image_mode(effective.image_mode)
         .with_images_enabled(!effective.no_images)


### PR DESCRIPTION
## Summary
- add a runtime toggle for markless mouse selection capture
- rename the public flags to --no-mouse-select / --mouse-select
- keep the change focused on the selection toggle and add a repo AGENTS entry for the release skill

## Testing
- ./scripts/check.sh