### PR TITLE
Add Kitty text sizing protocol for headings

### DIFF
--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -271,6 +271,7 @@ impl App {
         let mut frame_idx: u64 = 0;
         let mut needs_render = true;
         let mut mouse_capture_enabled = false;
+        let mut last_large_text_vp_offset: Option<usize> = None;
 
         loop {
             // Recreate watcher if the viewed file changed (e.g. browse mode navigation)
@@ -423,14 +424,21 @@ impl App {
                     ),
                 );
 
-                // Clear stale terminal buffer after returning from external process,
-                // or every frame when large text is active. OSC 66 multi-cell
-                // characters live outside ratatui's buffer; without a full clear
-                // ratatui's differential rendering leaves stale fragments when
-                // the viewport scrolls.
-                if model.needs_full_redraw || model.large_text {
+                // Clear stale terminal buffer after returning from external process
+                if model.needs_full_redraw {
                     terminal.clear()?;
                     model.needs_full_redraw = false;
+                }
+
+                // When large text is active, force a full clear only when the
+                // viewport scrolls — that's when stale OSC 66 multi-cell
+                // fragments appear. Mouse moves and other repaints don't need it.
+                if model.large_text {
+                    let current_offset = model.viewport.offset();
+                    if last_large_text_vp_offset != Some(current_offset) {
+                        terminal.clear()?;
+                        last_large_text_vp_offset = Some(current_offset);
+                    }
                 }
 
                 // Render

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -423,8 +423,12 @@ impl App {
                     ),
                 );
 
-                // Clear stale terminal buffer after returning from external process
-                if model.needs_full_redraw {
+                // Clear stale terminal buffer after returning from external process,
+                // or every frame when large text is active. OSC 66 multi-cell
+                // characters live outside ratatui's buffer; without a full clear
+                // ratatui's differential rendering leaves stale fragments when
+                // the viewport scrolls.
+                if model.needs_full_redraw || model.large_text {
                     terminal.clear()?;
                     model.needs_full_redraw = false;
                 }

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -152,6 +152,7 @@ impl App {
         model.images_enabled = self.images_enabled;
         model.wrap_width = self.wrap_width;
         model.no_inline_math = self.no_inline_math;
+        model.large_text = self.large_text;
         model.external_editor.clone_from(&self.editor);
         model
             .config_global_path
@@ -177,10 +178,9 @@ impl App {
             }
         }
 
-        // Reparse with mermaid-as-images now that the picker is configured.
-        // The initial parse used mermaid_as_images=false (before the picker
-        // was available), so mermaid blocks are still code blocks.
-        if model.should_render_mermaid_as_images() {
+        // Reparse with mermaid-as-images now that the picker is configured,
+        // or with large_text to strip heading prefixes and reserve extra rows.
+        if model.should_render_mermaid_as_images() || model.large_text {
             model.reflow_layout();
         }
 
@@ -432,6 +432,24 @@ impl App {
                 // Render
                 let draw_start = Instant::now();
                 terminal.draw(|frame| Self::view(model, frame))?;
+
+                // Post-render: write large-text headings via OSC 66 sequences
+                if model.large_text {
+                    let term_size = terminal.size()?;
+                    let term_area =
+                        ratatui::prelude::Rect::new(0, 0, term_size.width, term_size.height);
+                    let doc_area = if model.toc_visible {
+                        let chunks = crate::ui::split_main_columns(term_area);
+                        chunks.get(1).copied().unwrap_or(term_area)
+                    } else {
+                        term_area
+                    };
+                    let headings = crate::ui::collect_large_text_headings(model, doc_area);
+                    if let Err(e) = crate::ui::large_text::write_large_headings(&headings) {
+                        crate::perf::log_event("large_text.write.error", format!("err={e}"));
+                    }
+                }
+
                 crate::perf::log_event(
                     "frame.draw",
                     format!(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -33,6 +33,7 @@ pub struct App {
     wrap_width: Option<u16>,
     editor: Option<String>,
     no_inline_math: bool,
+    large_text: bool,
 }
 
 impl App {
@@ -51,6 +52,7 @@ impl App {
             wrap_width: None,
             editor: None,
             no_inline_math: false,
+            large_text: false,
         }
     }
 
@@ -107,6 +109,13 @@ impl App {
     #[must_use]
     pub const fn with_no_inline_math(mut self, enabled: bool) -> Self {
         self.no_inline_math = enabled;
+        self
+    }
+
+    /// Use Kitty text sizing protocol for large headings.
+    #[must_use]
+    pub const fn with_large_text(mut self, enabled: bool) -> Self {
+        self.large_text = enabled;
         self
     }
 

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -166,6 +166,8 @@ pub struct Model {
     pub failed_math_srcs: HashSet<String>,
     /// Disable inline (Unicode) math, rendering as images instead.
     pub no_inline_math: bool,
+    /// Use Kitty text sizing protocol for large headings.
+    pub large_text: bool,
 }
 
 impl std::fmt::Debug for Model {
@@ -243,6 +245,7 @@ impl Model {
             failed_mermaid_srcs: HashSet::new(),
             failed_math_srcs: HashSet::new(),
             no_inline_math: false,
+            large_text: false,
         }
     }
 
@@ -632,6 +635,7 @@ impl Model {
                 math_as_images: math,
                 failed_math_srcs: &self.failed_math_srcs,
                 no_inline_math: self.no_inline_math,
+                large_text: self.large_text,
             },
         ) {
             self.document = document;
@@ -725,6 +729,7 @@ impl Model {
                     math_as_images: self.should_render_math_as_images(),
                     failed_math_srcs: &self.failed_math_srcs,
                     no_inline_math: self.no_inline_math,
+                    large_text: self.large_text,
                 },
             )
         } else {
@@ -1090,6 +1095,7 @@ impl Default for Model {
             failed_mermaid_srcs: HashSet::new(),
             failed_math_srcs: HashSet::new(),
             no_inline_math: false,
+            large_text: false,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,6 +56,10 @@ pub struct ConfigFlags {
     pub no_inline_math: bool,
     /// Re-enable inline math (overrides saved `--no-inline-math`).
     pub inline_math: bool,
+    /// Use Kitty text sizing protocol for large headings.
+    pub large_text: bool,
+    /// Disable Kitty large text headings (overrides saved `--large-text`).
+    pub no_large_text: bool,
 }
 
 impl ConfigFlags {
@@ -80,6 +84,8 @@ impl ConfigFlags {
             editor: other.editor.clone().or_else(|| self.editor.clone()),
             no_inline_math: self.no_inline_math || other.no_inline_math,
             inline_math: self.inline_math || other.inline_math,
+            large_text: self.large_text || other.large_text,
+            no_large_text: self.no_large_text || other.no_large_text,
         }
     }
 }
@@ -320,6 +326,10 @@ pub fn parse_flag_tokens(tokens: &[String]) -> ConfigFlags {
             flags.no_inline_math = true;
         } else if token == "--inline-math" {
             flags.inline_math = true;
+        } else if token == "--large-text" {
+            flags.large_text = true;
+        } else if token == "--no-large-text" {
+            flags.no_large_text = true;
         }
         i += 1;
     }

--- a/src/document/parser.rs
+++ b/src/document/parser.rs
@@ -25,6 +25,8 @@ pub struct DiagramRenderOpts<'a> {
     pub failed_math_srcs: &'a HashSet<String>,
     /// Disable inline (Unicode) math, rendering as images instead.
     pub no_inline_math: bool,
+    /// Use Kitty text sizing protocol for large headings.
+    pub large_text: bool,
 }
 
 impl Default for DiagramRenderOpts<'_> {
@@ -35,6 +37,7 @@ impl Default for DiagramRenderOpts<'_> {
             math_as_images: false,
             failed_math_srcs: &EMPTY_HASH_SET,
             no_inline_math: false,
+            large_text: false,
         }
     }
 }
@@ -219,6 +222,7 @@ fn parse_with_all_options_internal<S: BuildHasher>(
         math_as_images: opts.math_as_images,
         failed_math_srcs: opts.failed_math_srcs,
         no_inline_math: opts.no_inline_math,
+        large_text: opts.large_text,
     };
     process_node(root, &mut ctx, 0, None);
 
@@ -277,6 +281,7 @@ struct ParseContext<'h, S: BuildHasher = std::collections::hash_map::RandomState
     math_as_images: bool,
     failed_math_srcs: &'h HashSet<String>,
     no_inline_math: bool,
+    large_text: bool,
 }
 
 fn process_node<'a, S: BuildHasher>(
@@ -308,11 +313,28 @@ fn process_node<'a, S: BuildHasher>(
 
             collect_inline_elements(node, line_num, &mut ctx.images, &mut ctx.link_refs);
 
-            let prefix = "#".repeat(heading.level as usize);
-            ctx.lines.push(RenderedLine::new(
-                format!("{prefix} {text}"),
-                LineType::Heading(heading.level),
-            ));
+            let scale = if ctx.large_text {
+                crate::ui::large_text::heading_scale(heading.level)
+            } else {
+                1
+            };
+
+            if scale > 1 {
+                // Large text mode: no # prefix, heading text only
+                ctx.lines
+                    .push(RenderedLine::new(text, LineType::Heading(heading.level)));
+                // Reserve extra rows for the scaled text (scale - 1 additional lines)
+                for _ in 1..scale {
+                    ctx.lines
+                        .push(RenderedLine::new(String::new(), LineType::Empty));
+                }
+            } else {
+                let prefix = "#".repeat(heading.level as usize);
+                ctx.lines.push(RenderedLine::new(
+                    format!("{prefix} {text}"),
+                    LineType::Heading(heading.level),
+                ));
+            }
             ctx.lines
                 .push(RenderedLine::new(String::new(), LineType::Empty));
         }
@@ -3963,5 +3985,116 @@ mod tests {
             has_x,
             "inline math $x$ before display math should be visible"
         );
+    }
+
+    #[test]
+    fn test_large_text_h1_no_hash_prefix() {
+        let doc = Document::parse_with_all_options_and_failures(
+            "# Title",
+            80,
+            &HashMap::new(),
+            &DiagramRenderOpts {
+                large_text: true,
+                ..DiagramRenderOpts::default()
+            },
+        )
+        .unwrap();
+        let heading_line = doc
+            .visible_lines(0, 20)
+            .into_iter()
+            .find(|l| *l.line_type() == LineType::Heading(1))
+            .expect("should have a heading line");
+        assert_eq!(heading_line.content(), "Title");
+        assert!(
+            !heading_line.content().starts_with('#'),
+            "large text heading should not have # prefix"
+        );
+    }
+
+    #[test]
+    fn test_large_text_h2_no_hash_prefix() {
+        let doc = Document::parse_with_all_options_and_failures(
+            "## Subtitle",
+            80,
+            &HashMap::new(),
+            &DiagramRenderOpts {
+                large_text: true,
+                ..DiagramRenderOpts::default()
+            },
+        )
+        .unwrap();
+        let heading_line = doc
+            .visible_lines(0, 20)
+            .into_iter()
+            .find(|l| *l.line_type() == LineType::Heading(2))
+            .expect("should have a heading line");
+        assert_eq!(heading_line.content(), "Subtitle");
+    }
+
+    #[test]
+    fn test_large_text_h3_keeps_hash_prefix() {
+        let doc = Document::parse_with_all_options_and_failures(
+            "### Section",
+            80,
+            &HashMap::new(),
+            &DiagramRenderOpts {
+                large_text: true,
+                ..DiagramRenderOpts::default()
+            },
+        )
+        .unwrap();
+        let heading_line = doc
+            .visible_lines(0, 20)
+            .into_iter()
+            .find(|l| *l.line_type() == LineType::Heading(3))
+            .expect("should have a heading line");
+        assert_eq!(heading_line.content(), "### Section");
+    }
+
+    #[test]
+    fn test_large_text_h1_reserves_extra_lines() {
+        let doc = Document::parse_with_all_options_and_failures(
+            "# Title\n\nBody text",
+            80,
+            &HashMap::new(),
+            &DiagramRenderOpts {
+                large_text: true,
+                ..DiagramRenderOpts::default()
+            },
+        )
+        .unwrap();
+        // H1 at scale 2: heading line + 1 extra empty line + 1 trailing empty line = 3 lines
+        // before body text
+        let lines = doc.visible_lines(0, 20);
+        let heading_idx = lines
+            .iter()
+            .position(|l| *l.line_type() == LineType::Heading(1))
+            .expect("should have heading");
+        // The line after the heading should be empty (reserved for scale)
+        assert_eq!(
+            *lines[heading_idx + 1].line_type(),
+            LineType::Empty,
+            "first line after heading should be empty (scale reservation)"
+        );
+    }
+
+    #[test]
+    fn test_large_text_disabled_keeps_hash_prefix() {
+        let doc = Document::parse_with_all_options_and_failures(
+            "# Title",
+            80,
+            &HashMap::new(),
+            &DiagramRenderOpts {
+                large_text: false,
+                ..DiagramRenderOpts::default()
+            },
+        )
+        .unwrap();
+        let heading_line = doc
+            .visible_lines(0, 20)
+            .into_iter()
+            .find(|l| *l.line_type() == LineType::Heading(1))
+            .expect("should have a heading line");
+        assert_eq!(heading_line.content(), "# Title");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,6 +98,14 @@ struct Cli {
     #[arg(long, conflicts_with = "no_inline_math")]
     inline_math: bool,
 
+    /// Use Kitty text sizing protocol for large headings
+    #[arg(long)]
+    large_text: bool,
+
+    /// Disable Kitty large text headings (overrides saved --large-text)
+    #[arg(long, conflicts_with = "large_text")]
+    no_large_text: bool,
+
     /// Save current command-line flags as defaults in .marklessrc
     #[arg(long)]
     save: bool,
@@ -359,6 +367,10 @@ fn main() -> Result<()> {
         .with_browse_mode(is_directory)
         .with_wrap_width(effective.wrap_width)
         .with_no_inline_math(effective.no_inline_math && !effective.inline_math)
+        .with_large_text(
+            !effective.no_large_text
+                && (effective.large_text || markless::ui::large_text::detect_support()),
+        )
         .with_editor(editor)
         .with_config_paths(
             Some(global_path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,11 +291,17 @@ fn main() -> Result<()> {
         default_hook(info);
     }));
 
-    // Initialize logging
+    // Initialize logging — suppress usvg font-matching warnings that corrupt
+    // the TUI when mermaid diagrams are rendered.
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive(tracing::Level::WARN.into()),
+                .add_directive(tracing::Level::WARN.into())
+                .add_directive(
+                    "usvg=error"
+                        .parse()
+                        .unwrap_or_else(|_| tracing::Level::ERROR.into()),
+                ),
         )
         .init();
 

--- a/src/ui/large_text.rs
+++ b/src/ui/large_text.rs
@@ -1,0 +1,331 @@
+//! Kitty text sizing protocol support for heading rendering.
+//!
+//! When the terminal supports the Kitty text sizing protocol (kitty >= 0.40.0),
+//! headings can be rendered at larger sizes using the OSC 66 escape sequence.
+//! This makes headers visually distinct without relying solely on color or
+//! `#` prefixes.
+//!
+//! Protocol reference: <https://sw.kovidgoyal.net/kitty/text-sizing-protocol/>
+
+/// Return the scale factor for a heading level when using large text.
+///
+/// H1 and H2 are rendered at 2× scale; all other levels use normal size.
+pub const fn heading_scale(level: u8) -> u8 {
+    match level {
+        1 | 2 => 2,
+        _ => 1,
+    }
+}
+
+/// Format the OSC 66 escape sequence for scaled text.
+///
+/// The sequence renders `text` at `scale`× size, occupying `scale` cells tall
+/// and `scale` cells wide per character. The width parameter `w` is set to 0
+/// (auto-calculate).
+///
+/// Returns `None` if `scale <= 1` (no escape needed) or if `text` is empty.
+pub fn format_osc66(text: &str, scale: u8) -> Option<String> {
+    if scale <= 1 || text.is_empty() {
+        return None;
+    }
+    // OSC 66 ; s=<scale> ; <text> BEL
+    Some(format!("\x1b]66;s={scale};{text}\x07"))
+}
+
+/// Truncate heading text to fit within the available column width at the given scale.
+///
+/// Each character occupies `scale` columns, so the maximum number of characters
+/// is `available_cols / scale`.
+pub fn truncate_to_fit(text: &str, available_cols: u16, scale: u8) -> &str {
+    if scale == 0 {
+        return text;
+    }
+    let max_chars = (available_cols / u16::from(scale)) as usize;
+    if text.chars().count() <= max_chars {
+        return text;
+    }
+    // Find the byte index at the max_chars boundary
+    text.char_indices()
+        .nth(max_chars)
+        .map_or(text, |(byte_idx, _)| &text[..byte_idx])
+}
+
+/// Detect whether the current terminal supports Kitty's text sizing protocol.
+///
+/// Currently uses a simple heuristic: checks for `KITTY_WINDOW_ID` or Ghostty
+/// (`TERM` containing "ghostty"). A more robust approach would use the CPR-based
+/// detection described in the protocol spec.
+pub fn detect_support() -> bool {
+    std::env::var("KITTY_WINDOW_ID").is_ok()
+}
+
+/// Information about a heading that needs post-render large text output.
+#[derive(Debug, Clone)]
+pub struct LargeTextHeading {
+    /// Terminal column (x) where the heading text starts
+    pub col: u16,
+    /// Terminal row (y) where the heading text starts
+    pub row: u16,
+    /// The heading text to render
+    pub text: String,
+    /// Scale factor (2 for H1/H2)
+    pub scale: u8,
+    /// ANSI color escape to apply before the heading
+    pub color_seq: String,
+}
+
+/// Collect visible headings that need large text rendering.
+///
+/// Returns a list of headings within the current viewport that have scale > 1.
+pub fn collect_visible_large_headings(
+    model: &crate::app::Model,
+    doc_area_x: u16,
+    doc_area_y: u16,
+    doc_area_width: u16,
+    doc_area_height: u16,
+) -> Vec<LargeTextHeading> {
+    let mut headings = Vec::new();
+    let vp_offset = model.viewport.offset();
+
+    for heading_ref in model.document.headings() {
+        let scale = heading_scale(heading_ref.level);
+        if scale <= 1 {
+            continue;
+        }
+
+        let heading_line = heading_ref.line;
+        // Check if heading is visible in viewport
+        if heading_line < vp_offset {
+            continue;
+        }
+        let rel_y = heading_line - vp_offset;
+        if rel_y >= doc_area_height as usize {
+            continue;
+        }
+
+        // Get the heading text from the document line
+        let text = if let Some(line) = model.document.line_at(heading_line) {
+            line.content().to_string()
+        } else {
+            continue;
+        };
+
+        let truncated = truncate_to_fit(&text, doc_area_width, scale);
+
+        // Build ANSI color sequence for the heading style
+        let style = crate::ui::style::style_for_line_type(&crate::document::LineType::Heading(
+            heading_ref.level,
+        ));
+        let color_seq = ansi_color_from_style(style);
+
+        // rel_y is bounded by doc_area_height (u16), safe to truncate
+        #[allow(clippy::cast_possible_truncation)]
+        let rel_y_u16 = rel_y as u16;
+        headings.push(LargeTextHeading {
+            col: doc_area_x,
+            row: doc_area_y + rel_y_u16,
+            text: truncated.to_string(),
+            scale,
+            color_seq,
+        });
+    }
+
+    headings
+}
+
+/// Write large text headings to stdout using OSC 66 escape sequences.
+///
+/// This should be called after `terminal.draw()` to overlay the scaled text
+/// on top of ratatui's rendered frame.
+///
+/// # Errors
+///
+/// Returns an error if writing to stdout fails.
+pub fn write_large_headings(headings: &[LargeTextHeading]) -> std::io::Result<()> {
+    use std::io::Write;
+
+    if headings.is_empty() {
+        return Ok(());
+    }
+
+    let mut out = std::io::stdout();
+    for heading in headings {
+        let Some(osc) = format_osc66(&heading.text, heading.scale) else {
+            continue;
+        };
+        // Move cursor to position (1-indexed for ANSI)
+        write!(
+            out,
+            "\x1b[{};{}H{}{}\x1b[0m",
+            heading.row + 1,
+            heading.col + 1,
+            heading.color_seq,
+            osc
+        )?;
+    }
+    out.flush()
+}
+
+/// Convert a ratatui Style's foreground color + modifiers to an ANSI escape sequence.
+fn ansi_color_from_style(style: ratatui::style::Style) -> String {
+    use ratatui::style::{Color, Modifier};
+
+    let mut parts = Vec::new();
+
+    // Bold
+    if style.add_modifier.contains(Modifier::BOLD) {
+        parts.push("1".to_string());
+    }
+    // Underlined
+    if style.add_modifier.contains(Modifier::UNDERLINED) {
+        parts.push("4".to_string());
+    }
+
+    // Foreground color
+    if let Some(fg) = style.fg {
+        match fg {
+            Color::Black => parts.push("30".to_string()),
+            Color::Red => parts.push("31".to_string()),
+            Color::Green => parts.push("32".to_string()),
+            Color::Yellow => parts.push("33".to_string()),
+            Color::Blue => parts.push("34".to_string()),
+            Color::Magenta => parts.push("35".to_string()),
+            Color::Cyan => parts.push("36".to_string()),
+            Color::White => parts.push("37".to_string()),
+            Color::Indexed(idx) => parts.push(format!("38;5;{idx}")),
+            Color::Rgb(r, g, b) => parts.push(format!("38;2;{r};{g};{b}")),
+            Color::LightRed => parts.push("91".to_string()),
+            Color::LightGreen => parts.push("92".to_string()),
+            Color::LightYellow => parts.push("93".to_string()),
+            Color::LightBlue => parts.push("94".to_string()),
+            Color::LightMagenta => parts.push("95".to_string()),
+            Color::LightCyan => parts.push("96".to_string()),
+            Color::Gray | Color::DarkGray => parts.push("90".to_string()),
+            Color::Reset => {}
+        }
+    }
+
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!("\x1b[{}m", parts.join(";"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_heading_scale_h1_returns_2() {
+        assert_eq!(heading_scale(1), 2);
+    }
+
+    #[test]
+    fn test_heading_scale_h2_returns_2() {
+        assert_eq!(heading_scale(2), 2);
+    }
+
+    #[test]
+    fn test_heading_scale_h3_returns_1() {
+        assert_eq!(heading_scale(3), 1);
+    }
+
+    #[test]
+    fn test_heading_scale_h4_through_h6_returns_1() {
+        for level in 4..=6 {
+            assert_eq!(heading_scale(level), 1, "H{level} should have scale 1");
+        }
+    }
+
+    #[test]
+    fn test_format_osc66_scale_2() {
+        let seq = format_osc66("Hello", 2).unwrap();
+        assert_eq!(seq, "\x1b]66;s=2;Hello\x07");
+    }
+
+    #[test]
+    fn test_format_osc66_scale_1_returns_none() {
+        assert!(format_osc66("Hello", 1).is_none());
+    }
+
+    #[test]
+    fn test_format_osc66_empty_text_returns_none() {
+        assert!(format_osc66("", 2).is_none());
+    }
+
+    #[test]
+    fn test_truncate_to_fit_no_truncation_needed() {
+        let text = "Short";
+        assert_eq!(truncate_to_fit(text, 80, 2), "Short");
+    }
+
+    #[test]
+    fn test_truncate_to_fit_truncates_at_scale_2() {
+        // 10 cols / scale 2 = 5 chars max
+        let text = "Hello World";
+        assert_eq!(truncate_to_fit(text, 10, 2), "Hello");
+    }
+
+    #[test]
+    fn test_truncate_to_fit_unicode() {
+        // 8 cols / scale 2 = 4 chars max
+        let text = "Héllo";
+        assert_eq!(truncate_to_fit(text, 8, 2), "Héll");
+    }
+
+    #[test]
+    fn test_truncate_to_fit_scale_1_no_truncation() {
+        let text = "Hello World";
+        assert_eq!(truncate_to_fit(text, 80, 1), "Hello World");
+    }
+
+    #[test]
+    fn test_ansi_color_bold_cyan() {
+        use ratatui::style::{Color, Modifier, Style};
+        let style = Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD);
+        let seq = ansi_color_from_style(style);
+        assert!(seq.contains("1"), "should have bold");
+        assert!(seq.contains("36"), "should have cyan fg");
+    }
+
+    #[test]
+    fn test_ansi_color_bold_underlined() {
+        use ratatui::style::{Color, Modifier, Style};
+        let style = Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD | Modifier::UNDERLINED);
+        let seq = ansi_color_from_style(style);
+        assert!(seq.contains("1"), "should have bold");
+        assert!(seq.contains("4"), "should have underline");
+    }
+
+    #[test]
+    fn test_ansi_color_indexed() {
+        use ratatui::style::{Color, Style};
+        let style = Style::default().fg(Color::Indexed(24));
+        let seq = ansi_color_from_style(style);
+        assert!(seq.contains("38;5;24"), "should have indexed color 24");
+    }
+
+    #[test]
+    fn test_ansi_color_empty_for_default_style() {
+        use ratatui::style::Style;
+        let style = Style::default();
+        let seq = ansi_color_from_style(style);
+        assert!(seq.is_empty(), "default style should produce empty seq");
+    }
+
+    #[test]
+    fn test_format_osc66_scale_3() {
+        let seq = format_osc66("Title", 3).unwrap();
+        assert_eq!(seq, "\x1b]66;s=3;Title\x07");
+    }
+
+    #[test]
+    fn test_write_large_headings_empty_is_ok() {
+        assert!(write_large_headings(&[]).is_ok());
+    }
+}

--- a/src/ui/large_text.rs
+++ b/src/ui/large_text.rs
@@ -52,11 +52,22 @@ pub fn truncate_to_fit(text: &str, available_cols: u16, scale: u8) -> &str {
 
 /// Detect whether the current terminal supports Kitty's text sizing protocol.
 ///
-/// Currently uses a simple heuristic: checks for `KITTY_WINDOW_ID` or Ghostty
-/// (`TERM` containing "ghostty"). A more robust approach would use the CPR-based
-/// detection described in the protocol spec.
+/// Checks `KITTY_WINDOW_ID` (always set by Kitty) and falls back to
+/// `TERM_PROGRAM=kitty` or `TERM` containing `xterm-kitty` for environments
+/// where `KITTY_WINDOW_ID` may not propagate (e.g. some SSH sessions).
 pub fn detect_support() -> bool {
-    std::env::var("KITTY_WINDOW_ID").is_ok()
+    if std::env::var("KITTY_WINDOW_ID").is_ok() {
+        return true;
+    }
+    if std::env::var("TERM_PROGRAM")
+        .ok()
+        .is_some_and(|v| v.eq_ignore_ascii_case("kitty"))
+    {
+        return true;
+    }
+    std::env::var("TERM")
+        .ok()
+        .is_some_and(|v| v.contains("xterm-kitty"))
 }
 
 /// Information about a heading that needs post-render large text output.

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,13 +10,14 @@ pub mod viewport;
 pub mod widgets;
 
 mod images;
+pub mod large_text;
 mod overlays;
 mod render;
 mod status;
 
 pub use overlays::{link_picker_content_top, link_picker_rect};
 pub use render::line_number_width;
-pub use render::{document_content_width, render, split_main_columns};
+pub use render::{collect_large_text_headings, document_content_width, render, split_main_columns};
 
 pub const DOCUMENT_LEFT_PADDING: u16 = 2;
 pub const TOC_WIDTH_PERCENT: u16 = 30;

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -166,6 +166,40 @@ fn render_browse_toc(model: &Model, frame: &mut Frame, area: Rect) {
     frame.render_widget(toc, area);
 }
 
+/// Collect large-text heading information after rendering the document.
+///
+/// Called from the event loop to overlay OSC 66 sequences after ratatui draws.
+pub fn collect_large_text_headings(
+    model: &Model,
+    area: Rect,
+) -> Vec<super::large_text::LargeTextHeading> {
+    if !model.large_text {
+        return Vec::new();
+    }
+
+    let search_active = model.search_query.is_some();
+    let toast_active = model.active_toast().is_some();
+    let hover_active = model.hovered_link_url.is_some();
+    let footer_rows =
+        1 + u16::from(search_active) + u16::from(toast_active) + u16::from(hover_active);
+    let doc_outer_area = Rect {
+        height: area.height.saturating_sub(footer_rows),
+        ..area
+    };
+    let doc_block = ratatui::widgets::Block::default()
+        .borders(ratatui::widgets::Borders::NONE)
+        .padding(ratatui::widgets::Padding::left(DOCUMENT_LEFT_PADDING));
+    let doc_area = doc_block.inner(doc_outer_area);
+
+    super::large_text::collect_visible_large_headings(
+        model,
+        doc_area.x,
+        doc_area.y,
+        doc_area.width,
+        doc_area.height,
+    )
+}
+
 fn render_document(model: &mut Model, frame: &mut Frame, area: Rect) {
     let search_active = model.search_query.is_some();
     let toast_active = model.active_toast().is_some();
@@ -263,6 +297,44 @@ fn render_document(model: &mut Model, frame: &mut Frame, area: Rect) {
     // Clear doc area first so placeholder/image background styles from previous frames do not leak.
     frame.render_widget(Clear, doc_outer_area);
     frame.render_widget(doc, doc_outer_area);
+
+    // Clear cells occupied by large-text headings so ratatui's text doesn't
+    // show underneath the OSC 66 overlay written after draw().
+    if model.large_text {
+        let vp_offset = model.viewport.offset();
+        for heading_ref in model.document.headings() {
+            let scale = super::large_text::heading_scale(heading_ref.level);
+            if scale <= 1 {
+                continue;
+            }
+            let heading_line = heading_ref.line;
+            if heading_line < vp_offset {
+                continue;
+            }
+            let rel_y = heading_line - vp_offset;
+            if rel_y >= doc_area.height as usize {
+                continue;
+            }
+            let frame_buf = frame.buffer_mut();
+            // rel_y is bounded by doc_area.height (u16), safe to truncate
+            #[allow(clippy::cast_possible_truncation)]
+            let rel_y_u16 = rel_y as u16;
+            // Clear `scale` rows for the heading
+            for row_offset in 0..u16::from(scale) {
+                let dst_row = doc_area.y + rel_y_u16 + row_offset;
+                if dst_row >= doc_area.y + doc_area.height {
+                    break;
+                }
+                for col in 0..doc_area.width {
+                    if doc_area.x + col < frame_buf.area.width {
+                        frame_buf[(doc_area.x + col, dst_row)]
+                            .set_symbol(" ")
+                            .set_skip(false);
+                    }
+                }
+            }
+        }
+    }
 
     if model.images_enabled {
         images::render_images(model, frame, doc_area);

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -298,43 +298,10 @@ fn render_document(model: &mut Model, frame: &mut Frame, area: Rect) {
     frame.render_widget(Clear, doc_outer_area);
     frame.render_widget(doc, doc_outer_area);
 
-    // Clear cells occupied by large-text headings so ratatui's text doesn't
-    // show underneath the OSC 66 overlay written after draw().
-    if model.large_text {
-        let vp_offset = model.viewport.offset();
-        for heading_ref in model.document.headings() {
-            let scale = super::large_text::heading_scale(heading_ref.level);
-            if scale <= 1 {
-                continue;
-            }
-            let heading_line = heading_ref.line;
-            if heading_line < vp_offset {
-                continue;
-            }
-            let rel_y = heading_line - vp_offset;
-            if rel_y >= doc_area.height as usize {
-                continue;
-            }
-            let frame_buf = frame.buffer_mut();
-            // rel_y is bounded by doc_area.height (u16), safe to truncate
-            #[allow(clippy::cast_possible_truncation)]
-            let rel_y_u16 = rel_y as u16;
-            // Clear `scale` rows for the heading
-            for row_offset in 0..u16::from(scale) {
-                let dst_row = doc_area.y + rel_y_u16 + row_offset;
-                if dst_row >= doc_area.y + doc_area.height {
-                    break;
-                }
-                for col in 0..doc_area.width {
-                    if doc_area.x + col < frame_buf.area.width {
-                        frame_buf[(doc_area.x + col, dst_row)]
-                            .set_symbol(" ")
-                            .set_skip(false);
-                    }
-                }
-            }
-        }
-    }
+    // Large-text headings: ratatui renders heading text at normal size as a
+    // fallback. The post-render step writes OSC 66 sequences on top, which
+    // Kitty replaces with scaled text. In unsupported terminals the normal
+    // text remains visible — no cells are cleared here.
 
     if model.images_enabled {
         images::render_images(model, frame, doc_area);


### PR DESCRIPTION
## Summary

- Implements the [Kitty text sizing protocol](https://sw.kovidgoyal.net/kitty/text-sizing-protocol/) (OSC 66) to render H1 and H2 headings at 2× scale
- Auto-detects Kitty terminal via `KITTY_WINDOW_ID` env var; can be explicitly controlled with `--large-text` / `--no-large-text` CLI flags (saveable via `--save`)
- When active, heading lines skip the `#` prefix and reserve extra vertical space for the scaled text; post-render step writes OSC 66 sequences directly to stdout

Closes #39

## Test plan

- [x] 22 new unit tests covering scale factors, OSC 66 sequence formatting, text truncation, ANSI color conversion, and parser behavior with/without large text
- [x] Full test suite passes (627 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual test in Kitty terminal with `markless --large-text README.md`
- [ ] Verify `--no-large-text` disables auto-detection in Kitty
- [ ] Verify non-Kitty terminals are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)