### PR TITLE
Fix UTF-8 char boundary handling in cursor movement and rendering

### DIFF
--- a/src/document/parser.rs
+++ b/src/document/parser.rs
@@ -2068,7 +2068,9 @@ fn fixup_link_lines(
                     .get(prefix_len..)
                     .unwrap_or("")
                     .trim_end();
-                let portion = &stripped[overlap_start - ls..overlap_end - ls];
+                let portion = stripped
+                    .get(overlap_start - ls..overlap_end - ls)
+                    .unwrap_or("");
                 if first_set {
                     extra.push(LinkRef {
                         text: portion.to_string(),

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -355,11 +355,24 @@ impl EditorBuffer {
         }
     }
 
+    /// Snap a byte offset to the nearest valid char boundary at or before `col`.
+    fn snap_to_char_boundary(&self, line_idx: usize, col: usize) -> usize {
+        let line = self.line_at(line_idx).unwrap_or_default();
+        let col = col.min(line.len());
+        // Walk backwards to find a valid char boundary
+        let mut c = col;
+        while c > 0 && !line.is_char_boundary(c) {
+            c -= 1;
+        }
+        c
+    }
+
     fn move_up(&mut self) {
         if self.cursor.line > 0 {
             self.cursor.line -= 1;
             let max_col = self.line_len(self.cursor.line);
-            self.cursor.col = self.cursor.col_memory.min(max_col);
+            self.cursor.col =
+                self.snap_to_char_boundary(self.cursor.line, self.cursor.col_memory.min(max_col));
         }
     }
 
@@ -367,7 +380,8 @@ impl EditorBuffer {
         if self.cursor.line + 1 < self.line_count() {
             self.cursor.line += 1;
             let max_col = self.line_len(self.cursor.line);
-            self.cursor.col = self.cursor.col_memory.min(max_col);
+            self.cursor.col =
+                self.snap_to_char_boundary(self.cursor.line, self.cursor.col_memory.min(max_col));
         }
     }
 }
@@ -882,5 +896,40 @@ mod tests {
         buf.delete_back();
         assert_eq!(buf.line_count(), 1);
         assert_eq!(buf.line_at(0), Some("helloworld".to_string()));
+    }
+
+    // --- UTF-8 boundary safety on vertical movement ---
+
+    #[test]
+    fn test_move_down_snaps_to_char_boundary_multibyte() {
+        // Line 0: "abc" (3 bytes, col_memory=3 after move_end)
+        // Line 1: "αβγ" (6 bytes, each char is 2 bytes)
+        // col_memory=3 is NOT a char boundary in "αβγ" (it's mid-β)
+        let mut buf = EditorBuffer::from_text("abc\nαβγ");
+        buf.move_end(); // col=3 on "abc"
+        assert_eq!(buf.cursor().col, 3);
+        buf.move_cursor(Direction::Down);
+        let col = buf.cursor().col;
+        let line = buf.line_at(1).unwrap();
+        assert!(
+            line.is_char_boundary(col),
+            "cursor col {col} is not a char boundary in {line:?}"
+        );
+    }
+
+    #[test]
+    fn test_move_up_snaps_to_char_boundary_multibyte() {
+        // Line 0: "αβγ" (6 bytes, each char is 2 bytes)
+        // Line 1: "abcde" (5 bytes)
+        // Move to col=5 on line 1, then up: col_memory=5 on "αβγ" is mid-γ
+        let mut buf = EditorBuffer::from_text("αβγ\nabcde");
+        buf.move_to(1, 5); // end of "abcde"
+        buf.move_cursor(Direction::Up);
+        let col = buf.cursor().col;
+        let line = buf.line_at(0).unwrap();
+        assert!(
+            line.is_char_boundary(col),
+            "cursor col {col} is not a char boundary in {line:?}"
+        );
     }
 }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -320,21 +320,25 @@ fn render_editor(model: &Model, frame: &mut Frame, area: Rect) {
         let mut spans = vec![Span::styled(line_num, Style::default().fg(Color::DarkGray))];
 
         if line_idx == cursor.line {
-            // Split line at cursor position for cursor rendering
-            let col = cursor.col.min(line_text.len());
+            // Split line at cursor position for cursor rendering.
+            // Snap col to a valid char boundary to avoid panics on multibyte text.
+            let mut col = cursor.col.min(line_text.len());
+            while col > 0 && !line_text.is_char_boundary(col) {
+                col -= 1;
+            }
             let before = &line_text[..col];
-            let cursor_char = line_text.get(col..col + 1).unwrap_or(" ");
-            let after = if col < line_text.len() {
-                &line_text[col + 1..]
-            } else {
-                ""
-            };
+            let cursor_char_str = line_text
+                .get(col..)
+                .and_then(|s| s.chars().next())
+                .map_or_else(|| " ".to_string(), |c| c.to_string());
+            let after_offset = col + cursor_char_str.len();
+            let after = line_text.get(after_offset..).unwrap_or("");
 
             if !before.is_empty() {
                 spans.push(Span::raw(before.to_string()));
             }
             spans.push(Span::styled(
-                cursor_char.to_string(),
+                cursor_char_str,
                 Style::default().bg(Color::White).fg(Color::Black),
             ));
             if !after.is_empty() {


### PR DESCRIPTION
## Summary
This PR fixes potential panics and incorrect cursor positioning when working with multibyte UTF-8 characters. The changes ensure that cursor positions are always snapped to valid UTF-8 character boundaries during vertical movement and rendering.

## Key Changes

- **Buffer vertical movement**: Added `snap_to_char_boundary()` helper method that walks backwards from a byte offset to find the nearest valid UTF-8 character boundary. This method is now called in `move_up()` and `move_down()` to ensure the cursor never lands in the middle of a multibyte character.

- **Cursor rendering**: Updated `render_editor()` in the UI layer to snap the cursor column to a valid char boundary before rendering. Also fixed the cursor character extraction to properly handle multibyte characters by using `chars().next()` instead of byte-based slicing, which could panic or produce incorrect output on non-ASCII text.

- **Parser safety**: Added bounds checking in `fixup_link_lines()` to use `.get()` instead of direct indexing, preventing potential panics on edge cases.

## Notable Implementation Details

- The `snap_to_char_boundary()` method uses `line.is_char_boundary()` to safely identify valid UTF-8 boundaries, walking backwards one byte at a time until a boundary is found.
- Cursor character rendering now correctly handles multibyte characters by extracting the full character width using `chars().next()` and `to_string()`, then calculating the proper offset for the "after" portion.
- Comprehensive test coverage added for both `move_up()` and `move_down()` with multibyte UTF-8 characters (Greek letters) to prevent regression.

https://claude.ai/code/session_01J88TRUMkjBFCGXeBwcMNSk