### PR TITLE
Fix --wrap-width truncating code blocks + pin Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt
       - name: Check formatting
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
       - name: Run clippy
@@ -30,6 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
       - name: Run tests
         run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }}
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -134,7 +134,12 @@ impl App {
         );
         let (document, effective_file) = if let Some(ref file) = initial_file {
             let raw_bytes = std::fs::read(file)?;
-            let doc = crate::document::prepare_document_from_bytes(file, raw_bytes, layout_width);
+            let doc = crate::document::prepare_document_from_bytes_with_widths(
+                file,
+                raw_bytes,
+                layout_width,
+                terminal_content_width,
+            );
             (doc, file.clone())
         } else {
             // No viewable file found; show empty document

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -114,26 +114,24 @@ impl App {
                     return Some(Message::UpdateSelection(line));
                 }
             }
-            MouseEventKind::Up(MouseButton::Left) => {
-                if model.selection.is_some() {
-                    if let Some(line) = doc_line_for_row(model, doc_area, mouse.row, true) {
-                        if model.selection_dragging() {
-                            return Some(Message::EndSelection(line));
-                        }
-                        let content_col = mouse
-                            .column
-                            .saturating_sub(doc_area.x + crate::ui::DOCUMENT_LEFT_PADDING)
-                            as usize;
-                        if Self::link_at_column(model, line, content_col).is_some() {
-                            return Some(Message::FollowLinkAtLine(line, Some(content_col)));
-                        }
-                        if image_at_line(model, line) {
-                            return Some(Message::FollowLinkAtLine(line, None));
-                        }
-                        return Some(Message::ClearSelection);
+            MouseEventKind::Up(MouseButton::Left) if model.selection.is_some() => {
+                if let Some(line) = doc_line_for_row(model, doc_area, mouse.row, true) {
+                    if model.selection_dragging() {
+                        return Some(Message::EndSelection(line));
+                    }
+                    let content_col = mouse
+                        .column
+                        .saturating_sub(doc_area.x + crate::ui::DOCUMENT_LEFT_PADDING)
+                        as usize;
+                    if Self::link_at_column(model, line, content_col).is_some() {
+                        return Some(Message::FollowLinkAtLine(line, Some(content_col)));
+                    }
+                    if image_at_line(model, line) {
+                        return Some(Message::FollowLinkAtLine(line, None));
                     }
                     return Some(Message::ClearSelection);
                 }
+                return Some(Message::ClearSelection);
             }
             _ => {}
         }
@@ -305,25 +303,23 @@ impl App {
 
         // Global keys — always apply regardless of TOC focus
         match key.code {
-            KeyCode::Char(' ') | KeyCode::PageDown => {
-                if model.viewport.can_scroll_down() {
-                    return Some(Message::PageDown);
-                }
+            KeyCode::Char(' ') | KeyCode::PageDown if model.viewport.can_scroll_down() => {
+                return Some(Message::PageDown);
             }
-            KeyCode::Char('b') | KeyCode::PageUp => {
-                if model.viewport.can_scroll_up() {
-                    return Some(Message::PageUp);
-                }
+            KeyCode::Char('b') | KeyCode::PageUp if model.viewport.can_scroll_up() => {
+                return Some(Message::PageUp);
             }
-            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                if model.viewport.can_scroll_down() {
-                    return Some(Message::HalfPageDown);
-                }
+            KeyCode::Char('d')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && model.viewport.can_scroll_down() =>
+            {
+                return Some(Message::HalfPageDown);
             }
-            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                if model.viewport.can_scroll_up() {
-                    return Some(Message::HalfPageUp);
-                }
+            KeyCode::Char('u')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && model.viewport.can_scroll_up() =>
+            {
+                return Some(Message::HalfPageUp);
             }
             KeyCode::Char('g') | KeyCode::Home => return Some(Message::GoToTop),
             KeyCode::Char('G') | KeyCode::End => return Some(Message::GoToBottom),

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -525,12 +525,19 @@ impl Model {
     }
 
     pub(super) fn layout_width(&self) -> u16 {
-        let terminal_width =
-            crate::ui::document_content_width(self.viewport.width(), self.toc_visible);
+        let terminal_width = self.max_doc_width();
         match self.wrap_width {
             Some(w) if w > 0 => terminal_width.min(w),
             _ => terminal_width,
         }
+    }
+
+    /// The maximum width any document element can occupy — the full document
+    /// area in the terminal, ignoring `--wrap-width`. Elements that don't
+    /// word-wrap (code blocks, tables) use this as their upper bound so the
+    /// user's prose-wrap preference doesn't truncate them.
+    pub(super) fn max_doc_width(&self) -> u16 {
+        crate::ui::document_content_width(self.viewport.width(), self.toc_visible)
     }
 
     pub(super) const fn toc_visible_rows(&self) -> usize {
@@ -619,12 +626,14 @@ impl Model {
     /// Shared implementation for `reflow_layout` (on resize / image height
     /// changes) and the mermaid-failure fallback path.
     fn reparse_document(&mut self) {
-        let width = self.layout_width();
+        let wrap_width = self.layout_width();
+        let max_width = self.max_doc_width();
         let mermaid = self.should_render_mermaid_as_images();
         let math = self.should_render_math_as_images();
-        if let Ok(document) = Document::parse_with_all_options_and_failures(
+        if let Ok(document) = Document::parse_with_all_options_widths(
             self.document.source(),
-            width,
+            wrap_width,
+            max_width,
             &self.image_layout_heights,
             &crate::document::DiagramRenderOpts {
                 mermaid_as_images: mermaid,
@@ -697,11 +706,11 @@ impl Model {
     /// Build a `Document` from raw file bytes, respecting current mermaid and
     /// image-layout settings.
     fn document_from_bytes(&self, path: &Path, raw_bytes: Vec<u8>) -> Result<Document> {
+        let wrap_width = self.layout_width();
+        let max_width = self.max_doc_width();
         if crate::document::is_binary(&raw_bytes) || crate::document::is_image_file(path) {
-            return Ok(crate::document::prepare_document_from_bytes(
-                path,
-                raw_bytes,
-                self.layout_width(),
+            return Ok(crate::document::prepare_document_from_bytes_with_widths(
+                path, raw_bytes, wrap_width, max_width,
             ));
         }
         let text = match String::from_utf8(raw_bytes) {
@@ -715,9 +724,10 @@ impl Model {
         // prepare_content wrapped in code fences (code/csv/image).
         // Everything else is plain text — render verbatim.
         if is_md || was_wrapped {
-            Document::parse_with_all_options_and_failures(
+            Document::parse_with_all_options_widths(
                 &content,
-                self.layout_width(),
+                wrap_width,
+                max_width,
                 &self.image_layout_heights,
                 &crate::document::DiagramRenderOpts {
                     mermaid_as_images: self.should_render_mermaid_as_images(),

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -693,8 +693,8 @@ impl Model {
             }
         }
 
-        dirs.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
-        files.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        dirs.sort_by_key(|a| a.name.to_lowercase());
+        files.sort_by_key(|a| a.name.to_lowercase());
 
         self.browse_entries.extend(dirs);
         self.browse_entries.extend(files);

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -932,6 +932,12 @@ impl Model {
         let range = self.selection_range()?;
         let mut lines = Vec::new();
         for idx in range {
+            // Code block body lines: copy the original source, not the
+            // (possibly truncated, frame-decorated) rendered text.
+            if let Some(raw) = self.document.code_block_raw_line(idx) {
+                lines.push(raw.to_string());
+                continue;
+            }
             if let Some(line) = self.document.line_at(idx) {
                 let link_refs: Vec<_> = self
                     .document

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -256,6 +256,38 @@ fn test_selected_text_strips_code_block_borders() {
 }
 
 #[test]
+fn test_selected_text_returns_raw_code_line_even_when_rendering_truncates() {
+    // Regression for #55: when a code line is wider than the terminal, the
+    // rendered line is truncated to fit (with no horizontal scroll). Copying
+    // it should still yield the *original* source line, not the truncated
+    // visible text — that's the main complaint in the bug report.
+    let long_line = "abcdefghij".repeat(20); // 200 chars
+    let md = format!("```\n{long_line}\n```");
+    // Terminal/wrap width 80 → rendered code body capped at 76 chars.
+    let doc = Document::parse_with_layout(&md, 80).unwrap();
+    let mut model = Model::new(PathBuf::from("test.md"), doc, (80, 24));
+
+    let body_idx = (0..model.document.line_count())
+        .find(|i| {
+            model
+                .document
+                .line_at(*i)
+                .is_some_and(|l| l.content().contains("abc"))
+        })
+        .expect("code body line missing");
+
+    model = update(model, Message::StartSelection(body_idx));
+    model = update(model, Message::UpdateSelection(body_idx));
+    model = update(model, Message::EndSelection(body_idx));
+
+    let (text, _lines) = model.selected_text().unwrap();
+    assert_eq!(
+        text, long_line,
+        "copied text should be the full original line, not the truncated rendered one"
+    );
+}
+
+#[test]
 fn test_selection_clears_after_mouse_up() {
     let doc = Document::parse("# Title\n\nLine one\n\nLine two").unwrap();
     let mut model = Model::new(PathBuf::from("test.md"), doc, (80, 24));

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -1958,6 +1958,38 @@ fn test_wrap_width_none_uses_terminal_width() {
 }
 
 #[test]
+fn test_wrap_width_does_not_truncate_code_blocks() {
+    // Regression for #55: prose wraps at wrap_width, but code blocks are not
+    // a prose target — they should keep their natural width up to the
+    // terminal area, so a narrower --wrap-width doesn't silently clip code
+    // lines (which breaks copy/paste).
+    let long_code = "x".repeat(100);
+    let md = format!("Some prose.\n\n```\n{long_code}\n```\n");
+    let doc = Document::parse_with_layout(&md, 80).unwrap();
+    let mut model = Model::new(PathBuf::from("test.md"), doc, (140, 24));
+    model.wrap_width = Some(60);
+    model.reflow_layout();
+
+    let body_line = model
+        .document
+        .visible_lines(0, 50)
+        .into_iter()
+        .find(|l| l.content().contains("xx"))
+        .expect("code body line missing");
+    let stripped = body_line
+        .content()
+        .strip_prefix("│ ")
+        .and_then(|s| s.strip_suffix(" │"))
+        .map(str::trim_end)
+        .expect("code line should have │ borders");
+    let x_count = stripped.chars().filter(|c| *c == 'x').count();
+    assert_eq!(
+        x_count, 100,
+        "code block content was truncated by wrap_width; got {x_count} chars"
+    );
+}
+
+#[test]
 fn test_wrap_width_larger_than_terminal_uses_terminal() {
     let md = "Short text.";
     let doc = Document::parse_with_layout(md, 80).unwrap();

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -251,9 +251,23 @@ pub fn prepare_document_from_bytes(
     bytes: Vec<u8>,
     layout_width: u16,
 ) -> Document {
+    prepare_document_from_bytes_with_widths(file_path, bytes, layout_width, layout_width)
+}
+
+/// Like [`prepare_document_from_bytes`] but with separate widths for prose
+/// wrapping and the document maximum width.
+///
+/// `wrap_width` controls where prose word-wraps. `max_width` is the upper
+/// bound for elements that don't word-wrap (code blocks, tables).
+pub fn prepare_document_from_bytes_with_widths(
+    file_path: &std::path::Path,
+    bytes: Vec<u8>,
+    wrap_width: u16,
+    max_width: u16,
+) -> Document {
     if is_image_file(file_path) {
         let md = image_markdown(file_path);
-        return Document::parse_with_layout(&md, layout_width)
+        return Document::parse_with_widths(&md, wrap_width, max_width)
             .unwrap_or_else(|_| Document::empty());
     }
     if !is_binary(&bytes) {
@@ -261,7 +275,7 @@ pub fn prepare_document_from_bytes(
             Ok(s) => prepare_content(file_path, s),
             Err(e) => prepare_content(file_path, e.to_string()),
         };
-        return Document::parse_with_layout(&content, layout_width)
+        return Document::parse_with_widths(&content, wrap_width, max_width)
             .unwrap_or_else(|_| Document::empty());
     }
     let name = file_path

--- a/src/document/parser.rs
+++ b/src/document/parser.rs
@@ -567,12 +567,18 @@ fn process_node<'a, S: BuildHasher>(
                 }
                 // Fall through to normal code block rendering if CSV parsing fails
             }
+            // When the longest line doesn't fit, clip to `max_width - 2` so
+            // visible content extends to the edge of the screen. The 5 trailing
+            // frame chars (3 padding + space + `│`) get clipped by the
+            // terminal — the missing right `│` is the visual cue that the
+            // line was truncated. Reserving more room (e.g. `- 4`) just
+            // leaves dead whitespace before the clipped border.
             let content_width = literal
                 .lines()
                 .map(UnicodeWidthStr::width)
                 .max()
                 .unwrap_or(0)
-                .min(ctx.code_block_max_width.saturating_sub(4).max(1));
+                .min(ctx.code_block_max_width.saturating_sub(2).max(1));
             let title = language.unwrap_or("code");
             let label = format!(" {title} ");
             let frame_inner_width = content_width + 2 + CODE_RIGHT_PADDING;
@@ -2818,8 +2824,10 @@ mod tests {
 
     #[test]
     fn test_code_block_clips_to_max_width_when_line_exceeds_terminal() {
-        // When even the terminal width can't fit the line, code blocks are
-        // truncated to max_width - 4 (room for │ borders + padding).
+        // When even the terminal width can't fit the line, content is clipped
+        // to max_width - 2 (just leaving room for the left `│ `). The right
+        // border and trailing padding overflow past max_width and get
+        // clipped by the terminal; the missing right `│` is the visual cue.
         let long_line = "x".repeat(200);
         let md = format!("```\n{long_line}\n```");
         let doc = Document::parse_with_widths(&md, 80, 100).unwrap();
@@ -2836,8 +2844,8 @@ mod tests {
             .expect("code line should have │ borders");
         let x_count = stripped.chars().filter(|c| *c == 'x').count();
         assert_eq!(
-            x_count, 96,
-            "expected line truncated to max_width-4=96; got {x_count}"
+            x_count, 98,
+            "expected line truncated to max_width-2=98; got {x_count}"
         );
     }
 

--- a/src/document/parser.rs
+++ b/src/document/parser.rs
@@ -65,6 +65,27 @@ impl Document {
         parse_with_layout(source, width, &HashMap::new())
     }
 
+    /// Parse with separate widths for prose wrapping and the document's
+    /// maximum width.
+    ///
+    /// `wrap_width` controls where prose is word-wrapped. `max_width` is the
+    /// usable terminal area and is used as the upper bound for elements that
+    /// don't word-wrap (code blocks, tables). This split lets users set a
+    /// narrow `--wrap-width` for prose without truncating code blocks below
+    /// the terminal width.
+    ///
+    /// # Errors
+    /// Returns an error if markdown parsing fails.
+    pub fn parse_with_widths(source: &str, wrap_width: u16, max_width: u16) -> Result<Self> {
+        Ok(parse_with_all_options_internal(
+            source,
+            wrap_width,
+            max_width,
+            &HashMap::new(),
+            &DiagramRenderOpts::default(),
+        ))
+    }
+
     /// # Errors
     /// Returns an error if markdown parsing fails.
     pub fn parse_with_image_heights(
@@ -143,6 +164,33 @@ impl Document {
             diagram_opts,
         ))
     }
+
+    /// Like [`parse_with_all_options_and_failures`] but with separate widths
+    /// for prose wrapping and the document maximum width.
+    ///
+    /// `wrap_width` controls where prose word-wraps. `max_width` is the upper
+    /// bound for elements that don't word-wrap (code blocks, tables). When
+    /// `--wrap-width` is set, callers should pass it as `wrap_width` and the
+    /// full terminal area as `max_width` so code blocks aren't clipped below
+    /// what the terminal could show.
+    ///
+    /// # Errors
+    /// Returns an error if markdown parsing fails.
+    pub fn parse_with_all_options_widths(
+        source: &str,
+        wrap_width: u16,
+        max_width: u16,
+        image_heights: &HashMap<String, usize>,
+        diagram_opts: &DiagramRenderOpts<'_>,
+    ) -> Result<Self> {
+        Ok(parse_with_all_options_internal(
+            source,
+            wrap_width,
+            max_width,
+            image_heights,
+            diagram_opts,
+        ))
+    }
 }
 
 /// Parse markdown source into a `Document`.
@@ -176,6 +224,7 @@ pub fn parse_with_layout<S: BuildHasher>(
     Ok(parse_with_all_options_internal(
         source,
         width,
+        width,
         image_heights,
         &DiagramRenderOpts::default(),
     ))
@@ -188,13 +237,18 @@ fn parse_with_all_options(
     image_heights: &HashMap<String, usize>,
     opts: &DiagramRenderOpts<'_>,
 ) -> Document {
-    parse_with_all_options_internal(source, width, image_heights, opts)
+    parse_with_all_options_internal(source, width, width, image_heights, opts)
 }
 
 /// Internal parse implementation that accepts any `BuildHasher` for image heights.
+///
+/// `wrap_width` controls where prose is word-wrapped. `max_width` is the
+/// upper bound for elements that don't word-wrap (code blocks, tables);
+/// it usually equals the available terminal width.
 fn parse_with_all_options_internal<S: BuildHasher>(
     source: &str,
-    width: u16,
+    wrap_width: u16,
+    max_width: u16,
     image_heights: &HashMap<String, usize, S>,
     opts: &DiagramRenderOpts<'_>,
 ) -> Document {
@@ -202,7 +256,8 @@ fn parse_with_all_options_internal<S: BuildHasher>(
     let options = create_options();
     let root = parse_document(&arena, source, &options);
 
-    let wrap_width = width.max(1) as usize;
+    let wrap_width = wrap_width.max(1) as usize;
+    let code_block_max_width = (max_width.max(1) as usize).max(wrap_width);
     let mut ctx = ParseContext {
         lines: Vec::new(),
         headings: Vec::new(),
@@ -214,6 +269,7 @@ fn parse_with_all_options_internal<S: BuildHasher>(
         math_sources: HashMap::new(),
         image_heights,
         wrap_width,
+        code_block_max_width,
         mermaid_as_images: opts.mermaid_as_images,
         failed_mermaid_srcs: opts.failed_mermaid_srcs,
         math_as_images: opts.math_as_images,
@@ -272,6 +328,7 @@ struct ParseContext<'h, S: BuildHasher = std::collections::hash_map::RandomState
     math_sources: HashMap<String, String>,
     image_heights: &'h HashMap<String, usize, S>,
     wrap_width: usize,
+    code_block_max_width: usize,
     mermaid_as_images: bool,
     failed_mermaid_srcs: &'h HashSet<String>,
     math_as_images: bool,
@@ -515,7 +572,7 @@ fn process_node<'a, S: BuildHasher>(
                 .map(UnicodeWidthStr::width)
                 .max()
                 .unwrap_or(0)
-                .min(ctx.wrap_width.saturating_sub(4).max(1));
+                .min(ctx.code_block_max_width.saturating_sub(4).max(1));
             let title = language.unwrap_or("code");
             let label = format!(" {title} ");
             let frame_inner_width = content_width + 2 + CODE_RIGHT_PADDING;
@@ -2730,6 +2787,58 @@ mod tests {
                 top_width
             );
         }
+    }
+
+    #[test]
+    fn test_code_block_uses_max_width_not_wrap_width() {
+        // Regression for #55: a code block containing a line wider than the
+        // user's --wrap-width should NOT be truncated. wrap_width controls
+        // prose wrapping; code blocks should preserve their natural width up
+        // to the terminal's available area.
+        let long_line = "x".repeat(100);
+        let md = format!("```\n{long_line}\n```");
+        let doc = Document::parse_with_widths(&md, 80, 120).unwrap();
+        let lines = doc.visible_lines(0, 10);
+        let body_line = lines
+            .iter()
+            .find(|l| l.content().contains("xx"))
+            .expect("code body line missing");
+        let content = body_line.content();
+        let stripped = content
+            .strip_prefix("│ ")
+            .and_then(|s| s.strip_suffix(" │"))
+            .map(str::trim_end)
+            .expect("code line should have │ borders");
+        let x_count = stripped.chars().filter(|c| *c == 'x').count();
+        assert_eq!(
+            x_count, 100,
+            "expected all 100 x's preserved; got {x_count} in {stripped:?}"
+        );
+    }
+
+    #[test]
+    fn test_code_block_clips_to_max_width_when_line_exceeds_terminal() {
+        // When even the terminal width can't fit the line, code blocks are
+        // truncated to max_width - 4 (room for │ borders + padding).
+        let long_line = "x".repeat(200);
+        let md = format!("```\n{long_line}\n```");
+        let doc = Document::parse_with_widths(&md, 80, 100).unwrap();
+        let lines = doc.visible_lines(0, 10);
+        let body_line = lines
+            .iter()
+            .find(|l| l.content().contains("xx"))
+            .expect("code body line missing");
+        let stripped = body_line
+            .content()
+            .strip_prefix("│ ")
+            .and_then(|s| s.strip_suffix(" │"))
+            .map(str::trim_end)
+            .expect("code line should have │ borders");
+        let x_count = stripped.chars().filter(|c| *c == 'x').count();
+        assert_eq!(
+            x_count, 96,
+            "expected line truncated to max_width-4=96; got {x_count}"
+        );
     }
 
     #[test]

--- a/src/document/types.rs
+++ b/src/document/types.rs
@@ -364,8 +364,7 @@ impl Document {
                 &block.raw_lines.join("\n"),
             );
 
-            for (line_idx, spans) in
-                (block.line_range.start..block.line_range.end).zip(highlighted.into_iter())
+            for (line_idx, spans) in (block.line_range.start..block.line_range.end).zip(highlighted)
             {
                 if line_idx >= self.lines.len() {
                     break;

--- a/src/document/types.rs
+++ b/src/document/types.rs
@@ -262,6 +262,23 @@ impl Document {
         &self.source
     }
 
+    /// Return the original (untruncated, undecorated) source line for a code
+    /// block body line at the given document index. Returns `None` for lines
+    /// that aren't inside a code block body (including the top/bottom border
+    /// lines, which sit just outside the recorded `line_range`).
+    ///
+    /// Used by selection/copy so that copied code matches the source even
+    /// when the rendered line was truncated to fit the terminal.
+    pub fn code_block_raw_line(&self, line_idx: usize) -> Option<&str> {
+        for block in &self.code_blocks {
+            if block.line_range.contains(&line_idx) {
+                let offset = line_idx - block.line_range.start;
+                return block.raw_lines.get(offset).map(String::as_str);
+            }
+        }
+        None
+    }
+
     /// Generate the text content for a hex line at the given document index.
     ///
     /// Returns the header line content for header indices, or generates the

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -134,7 +134,7 @@ impl FileWatcher {
                     irrelevant_events += 1;
                     crate::perf::log_event(
                         "watcher.irrelevant",
-                        format!("kind={:?} paths={:?}", ev.kind, ev.paths,),
+                        format!("kind={:?} paths={:?}", ev.kind, ev.paths),
                     );
                 }
                 Err(err) => {


### PR DESCRIPTION
## Summary
Closes #55. Three related changes plus a CI hygiene fix.

**1. Don't let `--wrap-width` truncate code blocks** (`src/document/parser.rs`, `src/app/model.rs`, `src/document/mod.rs`, `src/app/event_loop.rs`)

`wrap_width` was used both to word-wrap prose AND to clamp the maximum width of non-wrapping elements like code blocks. Setting `--wrap-width 80` on a wider terminal silently truncated code lines >76 chars, which broke copy/paste of those lines.

Split the parser's two width inputs:
- `wrap_width` — controls prose word-wrap (unchanged behavior)
- `max_width` — upper bound for elements that don't wrap (code blocks, tables); equals the available terminal area regardless of `--wrap-width`

New public API: `Document::parse_with_widths`, `parse_with_all_options_widths`, `prepare_document_from_bytes_with_widths`. Old API preserved (forwards `width` as both).

**2. Copy the raw code block source, not the rendered line** (`src/app/model.rs`, `src/document/types.rs`)

When a line is still wider than the terminal itself, it has to clip visually. The previous selection/copy path read from the rendered text, so the trailing characters were silently dropped on paste — the original complaint in #55. Selection now looks up `Document::code_block_raw_line` for any code body line and copies that verbatim.

**3. Maximize visible content when truncation is unavoidable** (`src/document/parser.rs`)

Even after fix #1, lines longer than the terminal need to clip. The old clamp at `max_width - 4` left the frame at `max_width + 3`, so the terminal lopped off the right `│`, the space before it, and one padding space — visible result had two cols of trailing whitespace before the (missing) border. Clip to `max_width - 2` instead so visible content extends to the screen edge. The missing right `│` remains the truncation indicator.

**4. Pin the Rust toolchain** (`rust-toolchain.toml`, `.github/workflows/*.yml`)

Discovered while running pre-push checks for this PR: CI used `dtolnay/rust-toolchain@stable`, so any new stable release that added clippy lints could break CI without anyone changing code (this happened to PR #56). Pin to 1.95.0 across both `ci.yml` and `release.yml` and add `rust-toolchain.toml` so local rustup matches. Bonus: fixed 9 clippy lints from Rust 1.95 in pre-existing code (`sort_by_key`, `collapsible_match`, `useless_conversion`, `unnecessary_trailing_comma`).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings` (Rust 1.95.0)
- [x] `cargo test` — 626 tests pass, 5 new (`select_poll_ms` x3 + `parse_with_widths` x3 + `wrap_width_does_not_truncate_code_blocks` + `selected_text_returns_raw_code_line_even_when_rendering_truncates`)
- [x] Manual verification with the yt-dlp `curl … --import` case from #55: code block renders at full width on a wide terminal, paste contains the trailing `t`
- [x] Manual verification with an over-terminal-width line: content reaches the screen edge, right `│` is the missing indicator, paste still returns the original source