### PR TITLE
Editor: render tabs at tab stops; Tab key inserts smart-tab spaces

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -422,7 +422,7 @@ impl App {
             KeyCode::Enter => Some(Message::EditorSplitLine),
             KeyCode::Backspace => Some(Message::EditorDeleteBack),
             KeyCode::Delete => Some(Message::EditorDeleteForward),
-            KeyCode::Tab => Some(Message::EditorInsertChar('\t')),
+            KeyCode::Tab => Some(Message::EditorInsertTab),
             KeyCode::Char(c) if !ctrl => Some(Message::EditorInsertChar(c)),
 
             _ => None,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2354,6 +2354,150 @@ fn test_editor_insert_char() {
 }
 
 #[test]
+fn test_editor_insert_tab_at_start_inserts_four_spaces() {
+    let model = create_test_model();
+    let model = enter_edit_mode(model);
+    let model = update(model, Message::EditorInsertTab);
+
+    let buf = model.editor_buffer.as_ref().unwrap();
+    assert!(buf.text().starts_with("    "), "got: {:?}", buf.text());
+    assert_eq!(buf.cursor().col, 4);
+}
+
+#[test]
+fn test_editor_insert_tab_snaps_to_next_tab_stop() {
+    // At col 1, Tab should insert only 3 spaces (reach col 4).
+    let model = create_test_model();
+    let model = enter_edit_mode(model);
+    let model = update(model, Message::EditorInsertChar('X'));
+    let model = update(model, Message::EditorInsertTab);
+
+    let buf = model.editor_buffer.as_ref().unwrap();
+    assert!(buf.text().starts_with("X   "), "got: {:?}", buf.text());
+    assert_eq!(buf.cursor().col, 4);
+}
+
+#[test]
+fn test_editor_preserves_tabs_full_input_pipeline() {
+    // Drives the full input pipeline (handle_key + update + side effects)
+    // to catch any conversion that the message-level test misses.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("tabs.md");
+    let original = "\thello\nworld\n";
+    std::fs::write(&path, original).unwrap();
+
+    let doc = Document::parse(original).unwrap();
+    let mut model = Model::new(path.clone(), doc, (80, 24));
+    let mut watcher = None;
+
+    let send = |model: &mut Model,
+                watcher: &mut Option<crate::watcher::FileWatcher>,
+                code: KeyCode,
+                mods: KeyModifiers| {
+        let key = event::KeyEvent::new(code, mods);
+        if let Some(msg) = App::handle_key(key, model) {
+            let new_model = update(std::mem::replace(model, create_test_model()), msg.clone());
+            *model = new_model;
+            App::handle_message_side_effects(model, watcher, &msg);
+        }
+    };
+
+    // Enter edit mode
+    send(
+        &mut model,
+        &mut watcher,
+        KeyCode::Char('e'),
+        KeyModifiers::NONE,
+    );
+    assert!(model.editor_mode, "should be in edit mode");
+    assert!(
+        model.editor_buffer.as_ref().unwrap().text().contains('\t'),
+        "buffer should have tab after entering edit mode, got: {:?}",
+        model.editor_buffer.as_ref().unwrap().text()
+    );
+
+    // Move down to line 2, end, type X
+    send(&mut model, &mut watcher, KeyCode::Down, KeyModifiers::NONE);
+    send(&mut model, &mut watcher, KeyCode::End, KeyModifiers::NONE);
+    send(
+        &mut model,
+        &mut watcher,
+        KeyCode::Char('X'),
+        KeyModifiers::NONE,
+    );
+
+    // Ctrl+S save
+    send(
+        &mut model,
+        &mut watcher,
+        KeyCode::Char('s'),
+        KeyModifiers::CONTROL,
+    );
+
+    let on_disk = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        on_disk.contains('\t'),
+        "tab should survive: got {:?}",
+        on_disk
+    );
+    assert!(on_disk.contains("worldX"), "edit should be saved");
+}
+
+#[test]
+fn test_editor_preserves_tabs_through_edit_and_save() {
+    // Repro: open a file with tabs, edit a *different* line, save.
+    // Tabs in the unedited line must survive the round-trip.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("tabs.md");
+    let original = "\thello\nworld\n";
+    std::fs::write(&path, original).unwrap();
+
+    let doc = Document::parse(original).unwrap();
+    let model = Model::new(path.clone(), doc, (80, 24));
+    let mut model = enter_edit_mode(model);
+
+    // Sanity: buffer loaded with the tab intact
+    assert!(
+        model.editor_buffer.as_ref().unwrap().text().contains('\t'),
+        "buffer should contain the tab after load"
+    );
+
+    // Move to line 2 and append an X
+    model = update(
+        model,
+        Message::EditorMoveCursor(crate::editor::Direction::Down),
+    );
+    model = update(model, Message::EditorMoveEnd);
+    model = update(model, Message::EditorInsertChar('X'));
+
+    let mut watcher = None;
+    App::handle_message_side_effects(&mut model, &mut watcher, &Message::EditorSave);
+
+    let on_disk = std::fs::read_to_string(&path).unwrap();
+    assert!(
+        on_disk.contains('\t'),
+        "tab on the unedited line should survive save, got: {:?}",
+        on_disk
+    );
+    assert!(on_disk.contains("worldX"), "edit should be saved");
+}
+
+#[test]
+fn test_editor_insert_tab_at_exact_stop_inserts_full_width() {
+    // At col 4 (already on a tab stop), Tab should insert a full 4 spaces.
+    let model = create_test_model();
+    let mut model = enter_edit_mode(model);
+    for ch in ['A', 'B', 'C', 'D'] {
+        model = update(model, Message::EditorInsertChar(ch));
+    }
+    let model = update(model, Message::EditorInsertTab);
+
+    let buf = model.editor_buffer.as_ref().unwrap();
+    assert!(buf.text().starts_with("ABCD    "), "got: {:?}", buf.text());
+    assert_eq!(buf.cursor().col, 8);
+}
+
+#[test]
 fn test_editor_delete_back() {
     let model = create_test_model();
     let model = enter_edit_mode(model);

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -114,6 +114,8 @@ pub enum Message {
     ExitEditMode,
     /// Insert a character at the cursor
     EditorInsertChar(char),
+    /// Insert spaces to advance to the next tab stop (Tab key, smart-tab behavior)
+    EditorInsertTab,
     /// Delete character before cursor (Backspace)
     EditorDeleteBack,
     /// Delete character at cursor (Delete)
@@ -482,6 +484,18 @@ pub fn update(mut model: Model, msg: Message) -> Model {
         Message::EditorInsertChar(ch) => {
             if let Some(buf) = &mut model.editor_buffer {
                 buf.insert_char(ch);
+                editor_ensure_cursor_visible(&mut model);
+            }
+        }
+        Message::EditorInsertTab => {
+            if let Some(buf) = &mut model.editor_buffer {
+                let cursor = buf.cursor();
+                let line = buf.line_at(cursor.line).unwrap_or_default();
+                let prefix_end = cursor.col.min(line.len());
+                let prefix = line.get(..prefix_end).unwrap_or("");
+                let visual_col = crate::ui::visual_col_after(prefix, 0);
+                let n = crate::ui::EDITOR_TAB_WIDTH - (visual_col % crate::ui::EDITOR_TAB_WIDTH);
+                buf.insert_str(&" ".repeat(n));
                 editor_ensure_cursor_visible(&mut model);
             }
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,7 +16,9 @@ mod status;
 
 pub use overlays::{link_picker_content_top, link_picker_rect};
 pub use render::line_number_width;
-pub use render::{document_content_width, render, split_main_columns};
+pub use render::{
+    EDITOR_TAB_WIDTH, document_content_width, render, split_main_columns, visual_col_after,
+};
 
 pub const DOCUMENT_LEFT_PADDING: u16 = 2;
 pub const TOC_WIDTH_PERCENT: u16 = 30;

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -1,8 +1,40 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Padding, Paragraph};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::Model;
 use crate::document::LineType;
+
+/// Visual width of a tab character in the editor.
+pub const EDITOR_TAB_WIDTH: usize = 4;
+
+/// Expand `\t` characters in `text` to spaces, advancing to the next
+/// `EDITOR_TAB_WIDTH` tab stop. Tracks running visual column so callers can
+/// chain segments (e.g. before/after cursor).
+///
+/// Returns the expanded string and the ending visual column.
+pub fn expand_tabs(text: &str, start_col: usize) -> (String, usize) {
+    let mut out = String::with_capacity(text.len());
+    let mut col = start_col;
+    for c in text.chars() {
+        if c == '\t' {
+            let n = EDITOR_TAB_WIDTH - (col % EDITOR_TAB_WIDTH);
+            for _ in 0..n {
+                out.push(' ');
+            }
+            col += n;
+        } else {
+            out.push(c);
+            col += UnicodeWidthChar::width(c).unwrap_or(0);
+        }
+    }
+    (out, col)
+}
+
+/// Visual column reached after rendering `text` starting from `start_col`.
+pub fn visual_col_after(text: &str, start_col: usize) -> usize {
+    expand_tabs(text, start_col).1
+}
 
 use super::{
     DOC_WIDTH_PERCENT, DOCUMENT_LEFT_PADDING, TOC_WIDTH_PERCENT, images, overlays, status,
@@ -326,7 +358,7 @@ fn render_editor(model: &Model, frame: &mut Frame, area: Rect) {
             while col > 0 && !line_text.is_char_boundary(col) {
                 col -= 1;
             }
-            let before = &line_text[..col];
+            let before = line_text.get(..col).unwrap_or("");
             let cursor_char_str = line_text
                 .get(col..)
                 .and_then(|s| s.chars().next())
@@ -334,18 +366,35 @@ fn render_editor(model: &Model, frame: &mut Frame, area: Rect) {
             let after_offset = col + cursor_char_str.len();
             let after = line_text.get(after_offset..).unwrap_or("");
 
-            if !before.is_empty() {
-                spans.push(Span::raw(before.to_string()));
+            let cursor_style = Style::default().bg(Color::White).fg(Color::Black);
+
+            let (before_expanded, mut vcol) = expand_tabs(before, 0);
+            if !before_expanded.is_empty() {
+                spans.push(Span::raw(before_expanded));
             }
-            spans.push(Span::styled(
-                cursor_char_str,
-                Style::default().bg(Color::White).fg(Color::Black),
-            ));
-            if !after.is_empty() {
-                spans.push(Span::raw(after.to_string()));
+
+            if cursor_char_str == "\t" {
+                // Tab under cursor: highlight one cell at the tab's start,
+                // fill the remainder of the tab stop with plain spaces.
+                let n = EDITOR_TAB_WIDTH - (vcol % EDITOR_TAB_WIDTH);
+                spans.push(Span::styled(" ".to_string(), cursor_style));
+                if n > 1 {
+                    spans.push(Span::raw(" ".repeat(n - 1)));
+                }
+                vcol += n;
+            } else {
+                let w = UnicodeWidthStr::width(cursor_char_str.as_str()).max(1);
+                spans.push(Span::styled(cursor_char_str, cursor_style));
+                vcol += w;
+            }
+
+            let (after_expanded, _) = expand_tabs(after, vcol);
+            if !after_expanded.is_empty() {
+                spans.push(Span::raw(after_expanded));
             }
         } else {
-            spans.push(Span::raw(line_text));
+            let (expanded, _) = expand_tabs(&line_text, 0);
+            spans.push(Span::raw(expanded));
         }
 
         content.push(Line::from(spans));

--- a/src/ui/tests.rs
+++ b/src/ui/tests.rs
@@ -1155,3 +1155,92 @@ fn test_help_overlay_scroll_clamps() {
         "Config section should be visible at max scroll"
     );
 }
+
+#[test]
+fn test_expand_tabs_at_start() {
+    let (out, vcol) = super::render::expand_tabs("\thello", 0);
+    assert_eq!(out, "    hello");
+    assert_eq!(vcol, 9);
+}
+
+#[test]
+fn test_expand_tabs_partial_stop() {
+    // "ab" → vcol 2, then \t expands to 2 spaces (to reach 4)
+    let (out, vcol) = super::render::expand_tabs("ab\tc", 0);
+    assert_eq!(out, "ab  c");
+    assert_eq!(vcol, 5);
+}
+
+#[test]
+fn test_expand_tabs_with_start_col() {
+    // Starting at vcol 1, a tab should expand by 3 to reach vcol 4
+    let (out, vcol) = super::render::expand_tabs("\t", 1);
+    assert_eq!(out, "   ");
+    assert_eq!(vcol, 4);
+}
+
+#[test]
+fn test_expand_tabs_no_tabs() {
+    let (out, vcol) = super::render::expand_tabs("plain", 3);
+    assert_eq!(out, "plain");
+    assert_eq!(vcol, 8);
+}
+
+#[test]
+fn test_editor_renders_existing_tab_as_spaces() {
+    let md = "\thello";
+    let doc = Document::parse(md).unwrap();
+    let mut model = Model::new(PathBuf::from("test.md"), doc, (80, 24));
+    model = crate::app::update(model, crate::app::Message::EnterEditMode);
+    let mut watcher = None;
+    crate::app::App::handle_message_side_effects(
+        &mut model,
+        &mut watcher,
+        &crate::app::Message::EnterEditMode,
+    );
+
+    let mut terminal = create_test_terminal();
+    terminal.draw(|frame| render(&mut model, frame)).unwrap();
+
+    let buffer = terminal.backend().buffer();
+    let first_row: String = (0..buffer.area.width)
+        .map(|x| buffer.cell((x, 0)).unwrap().symbol().to_string())
+        .collect();
+
+    assert!(
+        first_row.contains("    hello") || first_row.contains(" hello"),
+        "Tab should render as spaces to the next tab stop, got: '{first_row}'"
+    );
+    assert!(
+        !first_row.contains('\t'),
+        "Raw tab byte should not appear in rendered output, got: '{first_row}'"
+    );
+}
+
+#[test]
+fn test_editor_renders_tab_mid_line_to_tab_stop() {
+    // "ab\tc": tab at vcol 2 should expand 2 spaces to reach vcol 4,
+    // so the rendered text contains "ab  c".
+    let md = "ab\tc";
+    let doc = Document::parse(md).unwrap();
+    let mut model = Model::new(PathBuf::from("test.md"), doc, (80, 24));
+    model = crate::app::update(model, crate::app::Message::EnterEditMode);
+    let mut watcher = None;
+    crate::app::App::handle_message_side_effects(
+        &mut model,
+        &mut watcher,
+        &crate::app::Message::EnterEditMode,
+    );
+
+    let mut terminal = create_test_terminal();
+    terminal.draw(|frame| render(&mut model, frame)).unwrap();
+
+    let buffer = terminal.backend().buffer();
+    let first_row: String = (0..buffer.area.width)
+        .map(|x| buffer.cell((x, 0)).unwrap().symbol().to_string())
+        .collect();
+    assert!(
+        first_row.contains("ab  c"),
+        "Tab mid-line should expand to next tab stop, got: '{first_row}'"
+    );
+}


### PR DESCRIPTION
## Motivation

Pressing Tab in the built-in editor inserted a literal `\t`, which ratatui renders at zero width — so the keystroke looked like a no-op. Files opened with existing tab indentation had the same problem: tabs were invisible, and the cursor appeared at the wrong cell whenever it sat past one.

## Change

- **Tab key** now inserts spaces to the next tab stop (`4 - visual_col % 4`). Smart-tab: at col 0 → 4 spaces, at col 1 → 3 spaces, at col 4 → 4 spaces.
- **Render** expands each `\t` visually to the next tab stop, but keeps the raw `\t` byte in the rope. A file with tabs that's opened and saved without edits is byte-for-byte unchanged on disk.
- **Cursor on a tab**: one-cell highlight at the tab's start, padded with plain spaces to the next tab stop.

`EDITOR_TAB_WIDTH` is a const (4) — matches CommonMark's tab treatment for indented code blocks. Configurability can come later if anyone asks.

## Tests

9 new tests:
- `expand_tabs` unit tests (at start, partial stop, with start_col, no tabs)
- `EditorInsertTab` at col 0 / mid-line / on tab stop
- Editor renders existing `\t` as spaces (at start of line and mid-line)
- Round-trip: file with tabs survives edit on a different line + save (full input pipeline + message-level)

## Test plan

- [ ] Open a file with tab indentation, confirm it renders as proper indentation (not invisible)
- [ ] Edit a different line, save, verify `od -c` still shows `\t` in the original tab positions
- [ ] Press Tab in the editor, confirm spaces are inserted to next 4-col stop
- [ ] Backspace immediately after a tab deletes the whole tab (4 visual cells vanish at once)