### PR TITLE
Fix sluggish input on iOS SSH clients (issue #53)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2286,6 +2286,7 @@ dependencies = [
  "crossterm",
  "csv",
  "image",
+ "libc",
  "mermaid-rs-renderer",
  "mitex",
  "mitex-spec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 unicode-width = "0.2"
 ropey = "1.6.1"
 
+# Unix-only: O_NONBLOCK constant for /dev/tty (see src/term_query.rs).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 # Testing
 proptest = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod mermaid;
 pub mod perf;
 pub mod search;
 pub mod svg;
+pub mod term_query;
 pub mod ui;
 pub mod watcher;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ use markless::config::{
 };
 use markless::highlight::{HighlightBackground, set_background_mode};
 use markless::perf;
+#[cfg(unix)]
+use markless::term_query::{parse_osc11_reply, read_osc_response};
 
 /// A terminal markdown viewer with image support
 #[derive(Parser, Debug)]
@@ -119,54 +121,27 @@ fn query_terminal_background() -> std::io::Result<Option<(u8, u8, u8)>> {
 
 #[cfg(unix)]
 fn query_terminal_background() -> std::io::Result<Option<(u8, u8, u8)>> {
-    use std::io::{Read, Write};
-    use std::sync::mpsc;
+    use std::os::unix::fs::OpenOptionsExt;
 
-    let (tx, rx) = mpsc::channel();
-
+    // Open /dev/tty non-blocking so the bounded read in
+    // `read_osc_response` can poll for the reply without spawning a
+    // background reader that would race crossterm for keystrokes on
+    // terminals that don't reply to OSC 11 (issue #53).
     let mut io = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
+        .custom_flags(libc::O_NONBLOCK)
         .open("/dev/tty")?;
-    let reader = io.try_clone()?;
 
-    // OSC 11 query: ESC ] 11 ; ? BEL
-    io.write_all(b"\x1b]11;?\x07")?;
-    io.flush()?;
-
-    std::thread::spawn(move || {
-        let mut reader = reader;
-        let mut buf = [0u8; 256];
-        let mut collected: Vec<u8> = Vec::new();
-        loop {
-            match reader.read(&mut buf) {
-                Ok(0) => {}
-                Ok(n) => {
-                    collected.extend_from_slice(&buf[..n]);
-                    if collected.contains(&b'\x07') || collected.windows(2).any(|w| w == b"\x1b\\")
-                    {
-                        let _ = tx.send(collected);
-                        break;
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-    });
-
-    let collected: Vec<u8> = rx
-        .recv_timeout(Duration::from_millis(75))
-        .unwrap_or_default();
-
-    let mut found: Option<(u8, u8, u8)> = None;
-    if !collected.is_empty() {
-        let text = String::from_utf8_lossy(&collected);
-        if text.contains("rgb:") {
-            found = parse_osc11_reply(&text);
-        }
+    let collected = read_osc_response(&mut io, Duration::from_millis(75));
+    if collected.is_empty() {
+        return Ok(None);
     }
-
-    Ok(found)
+    let text = String::from_utf8_lossy(&collected);
+    if !text.contains("rgb:") {
+        return Ok(None);
+    }
+    Ok(parse_osc11_reply(&text))
 }
 
 fn theme_from_rgb(r: u8, g: u8, b: u8) -> HighlightBackground {
@@ -245,33 +220,6 @@ fn relaunch_with_theme(mode: HighlightBackground, raw_args: &[String]) -> Result
         anyhow::bail!("failed to relaunch markless with detected theme");
     }
     Ok(())
-}
-
-fn parse_osc11_reply(reply: &str) -> Option<(u8, u8, u8)> {
-    // Expect: ESC ] 11 ; rgb:RRRR/GGGG/BBBB BEL or ST
-    let start = reply.find("rgb:")?;
-    let data = &reply[start + 4..];
-    let mut parts = data.split(['/', '\x07', '\x1b']);
-    let r = parts.next()?;
-    let g = parts.next()?;
-    let b = parts.next()?;
-    Some((
-        parse_osc_component(r)?,
-        parse_osc_component(g)?,
-        parse_osc_component(b)?,
-    ))
-}
-
-fn parse_osc_component(s: &str) -> Option<u8> {
-    let hex = s.trim();
-    if hex.len() >= 4 {
-        let v = u16::from_str_radix(&hex[..4], 16).ok()?;
-        Some((v >> 8) as u8)
-    } else if hex.len() == 2 {
-        u8::from_str_radix(hex, 16).ok()
-    } else {
-        None
-    }
 }
 
 fn main() -> Result<()> {

--- a/src/term_query.rs
+++ b/src/term_query.rs
@@ -1,0 +1,190 @@
+//! Terminal background-color query helpers (OSC 11).
+//!
+//! At startup `markless` sends an OSC 11 query asking the terminal for
+//! its background color, then picks a syntax-highlight theme readable
+//! against it. The terminal replies with `ESC ] 11 ; rgb:RRRR/GGGG/BBBB`
+//! terminated by `BEL` or `ESC \`.
+//!
+//! [`read_osc_response`] runs the query and the bounded read on the
+//! calling thread against a non-blocking fd, which is what makes it
+//! safe to call from `main`: no reader can outlive the function and
+//! steal subsequent keystrokes from crossterm (issue #53).
+
+use std::io::{ErrorKind, Read, Write};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+/// OSC 11 query payload: `ESC ] 11 ; ? BEL`.
+const OSC11_QUERY: &[u8] = b"\x1b]11;?\x07";
+
+/// Send an OSC 11 query on `io` and collect the reply until a terminator
+/// (`BEL` or `ESC \`) arrives or `timeout` elapses.
+///
+/// `io` must already be in non-blocking mode. Returns the raw bytes
+/// received, empty on timeout or error.
+pub fn read_osc_response<S: Read + Write>(io: &mut S, timeout: Duration) -> Vec<u8> {
+    if io.write_all(OSC11_QUERY).is_err() {
+        return Vec::new();
+    }
+    let _ = io.flush();
+
+    let deadline = Instant::now() + timeout;
+    let mut collected: Vec<u8> = Vec::with_capacity(64);
+    let mut buf = [0u8; 256];
+
+    while Instant::now() < deadline {
+        match io.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                collected.extend_from_slice(&buf[..n]);
+                if has_osc_terminator(&collected) {
+                    break;
+                }
+            }
+            Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                sleep(Duration::from_millis(5));
+            }
+            Err(_) => break,
+        }
+    }
+
+    collected
+}
+
+fn has_osc_terminator(bytes: &[u8]) -> bool {
+    bytes.contains(&b'\x07') || bytes.windows(2).any(|w| w == b"\x1b\\")
+}
+
+/// Parse an OSC 11 reply payload into an 8-bit-per-channel RGB triple.
+/// Returns `None` if the reply doesn't contain an `rgb:` section or is
+/// otherwise malformed.
+pub fn parse_osc11_reply(reply: &str) -> Option<(u8, u8, u8)> {
+    let start = reply.find("rgb:")?;
+    let data = reply.get(start + 4..)?;
+    let mut parts = data.split(['/', '\x07', '\x1b']);
+    let r = parts.next()?;
+    let g = parts.next()?;
+    let b = parts.next()?;
+    Some((
+        parse_osc_component(r)?,
+        parse_osc_component(g)?,
+        parse_osc_component(b)?,
+    ))
+}
+
+/// Parse a single hex color component. Terminals usually emit four hex
+/// digits per channel; some emit two.
+fn parse_osc_component(s: &str) -> Option<u8> {
+    let hex = s.trim();
+    if hex.len() >= 4 {
+        let head = hex.get(..4)?;
+        let v = u16::from_str_radix(head, 16).ok()?;
+        u8::try_from(v >> 8).ok()
+    } else if hex.len() == 2 {
+        u8::from_str_radix(hex, 16).ok()
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_osc11_reply_handles_four_digit_components() {
+        let reply = "\x1b]11;rgb:1818/2828/3838\x07";
+        assert_eq!(parse_osc11_reply(reply), Some((0x18, 0x28, 0x38)));
+    }
+
+    #[test]
+    fn parse_osc11_reply_handles_two_digit_components() {
+        let reply = "\x1b]11;rgb:18/28/38\x07";
+        assert_eq!(parse_osc11_reply(reply), Some((0x18, 0x28, 0x38)));
+    }
+
+    #[test]
+    fn parse_osc11_reply_handles_st_terminator() {
+        let reply = "\x1b]11;rgb:0000/0000/0000\x1b\\";
+        assert_eq!(parse_osc11_reply(reply), Some((0x00, 0x00, 0x00)));
+    }
+
+    #[test]
+    fn parse_osc11_reply_rejects_missing_rgb_prefix() {
+        assert_eq!(parse_osc11_reply("\x1b]11;1234/5678/9abc\x07"), None);
+    }
+
+    #[cfg(unix)]
+    fn pair() -> (
+        std::os::unix::net::UnixStream,
+        std::os::unix::net::UnixStream,
+    ) {
+        let (a, b) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+        a.set_nonblocking(true).expect("set_nonblocking");
+        (a, b)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_osc_response_returns_promptly_on_silent_peer() {
+        let (mut client, _server) = pair();
+        let start = Instant::now();
+        let collected = read_osc_response(&mut client, Duration::from_millis(50));
+        let elapsed = start.elapsed();
+        assert!(collected.is_empty(), "got {collected:?}");
+        assert!(
+            elapsed < Duration::from_millis(250),
+            "took {elapsed:?}, expected to bail out near the 50 ms deadline",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_osc_response_collects_complete_reply() {
+        let (mut client, mut server) = pair();
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 32];
+            let _ = server.read(&mut buf);
+            let _ = server.write_all(b"\x1b]11;rgb:1818/2828/3838\x07");
+        });
+        let collected = read_osc_response(&mut client, Duration::from_millis(500));
+        assert!(collected.windows(4).any(|w| w == b"rgb:"));
+        assert!(collected.contains(&b'\x07'));
+        let text = String::from_utf8_lossy(&collected);
+        assert_eq!(parse_osc11_reply(&text), Some((0x18, 0x28, 0x38)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_osc_response_reassembles_split_reads() {
+        let (mut client, mut server) = pair();
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 32];
+            let _ = server.read(&mut buf);
+            let _ = server.write_all(b"\x1b]11;rgb:");
+            std::thread::sleep(Duration::from_millis(15));
+            let _ = server.write_all(b"1818/2828/3838\x07");
+        });
+        let collected = read_osc_response(&mut client, Duration::from_millis(500));
+        let text = String::from_utf8_lossy(&collected);
+        assert_eq!(parse_osc11_reply(&text), Some((0x18, 0x28, 0x38)));
+    }
+
+    /// Regression test for issue #53: bytes written to the peer after
+    /// `read_osc_response` returns must still be readable by the caller.
+    /// A stray reader holding the fd would consume them instead.
+    #[cfg(unix)]
+    #[test]
+    fn read_osc_response_does_not_leave_orphan_consumer() {
+        let (mut client, mut server) = pair();
+        let _ = read_osc_response(&mut client, Duration::from_millis(20));
+
+        server
+            .write_all(b"post-timeout bytes")
+            .expect("server write");
+        client.set_nonblocking(false).expect("set blocking");
+        let mut buf = [0u8; 64];
+        let n = client.read(&mut buf).expect("read after timeout");
+        assert_eq!(&buf[..n], b"post-timeout bytes");
+    }
+}


### PR DESCRIPTION
Fixes #53.

## Bug

Input feels sluggish — roughly half of keystrokes appear to be dropped — when `markless` is used over SSH from iOS terminal apps such as Termius and Shelly. The previous responsiveness patch (#56) helped with split escape sequences inside crossterm but didn't help users running `--no-images`, because the cause was elsewhere.

The root cause is in `query_terminal_background()` in `src/main.rs`. At startup `markless` sends an OSC 11 query (`ESC ] 11 ; ? BEL`) asking the terminal for its background color so it can pick a syntax-highlight theme readable against it. The code:

1. Opens `/dev/tty` for read+write
2. `try_clone()`s the fd
3. Spawns a **detached** thread that loops on a blocking `reader.read(&mut buf)` until it sees an OSC terminator (`BEL` or `ESC \`)
4. The main thread does `rx.recv_timeout(75ms)` and proceeds

The bug: `read()` is blocking and the loop only exits on a terminator or an error. Many iOS SSH clients don't implement OSC 11 and simply send nothing back. The main thread times out at 75 ms and continues, but **the detached reader thread keeps blocking inside `read()` on `/dev/tty` for the lifetime of the process**. Because `/dev/tty` and stdin reference the same underlying terminal device, that orphan thread races crossterm for every keystroke and silently consumes about half of them.

This is invisible from any terminal that does reply to OSC 11 (every desktop emulator does), which is why it survived this long.

## Fix

Move the OSC 11 query off the detached thread entirely. The work now happens on the calling thread against a non-blocking fd, so the file descriptor is dropped — and pending bytes drained by the kernel — before `query_terminal_background()` returns. There is structurally no way to leave a reader behind.

Concretely:

- Open `/dev/tty` with `std::os::unix::fs::OpenOptionsExt::custom_flags(libc::O_NONBLOCK)` so subsequent `read`s return `EAGAIN` immediately when there's nothing to read.
- Perform the OSC 11 send + bounded read on the calling thread with a new helper `term_query::read_osc_response`, which polls `read()` against the deadline, sleeping 5 ms between `ErrorKind::WouldBlock` retries and breaking out on the OSC terminator or timeout.
- Move the OSC reply parsers (`parse_osc11_reply`, `parse_osc_component`) into the same module so the parser and protocol live together.
- Add `libc = "0.2"` as a unix-only direct dependency, used only for the symbolic `libc::O_NONBLOCK` constant — no FFI calls and no `unsafe` code. `libc` is already a transitive dep via `crossterm` and `ratatui-image`, so binary size is unchanged.
- Cover the new helper with 8 tests in `src/term_query.rs`: 4 parser cases plus 4 `UnixStream::pair()`-based I/O tests for silent peers, complete replies, split reads, and a dedicated regression test (`read_osc_response_does_not_leave_orphan_consumer`) that writes bytes to the peer *after* the call returns and asserts the caller can still read them — the precise property the old code violated.

`src/main.rs` ends up 69 lines shorter; `query_terminal_background` is now a 14-line open-then-delegate.

## Why this approach

- **Targets the actual cause.** The bug isn't escape-sequence parsing in crossterm — that was #56 and didn't fully fix things. It's a literal second reader on `/dev/tty` that should never have existed past the timeout. Killing the detached thread is the only fix that addresses the cause.
- **Bug-by-construction protection.** With the read loop on the calling thread holding the fd, the helper can't leak a reader. The regression test pins this property in place against future refactors.
- **Portable.** `libc::O_NONBLOCK` is correct on every Unix target without per-OS `cfg` branches or magic numbers. `std::io::ErrorKind::WouldBlock` is the portable spelling of `EAGAIN`. The Windows code path (already `Ok(None)`) is untouched.
- **No `unsafe`.** The workspace lint `unsafe_code = "deny"` stays clean — `libc` is consulted only for a `pub const`, never for FFI. `libc::poll` would be the textbook approach but needs `unsafe extern "C"`; busy-poll is functionally equivalent for a one-shot 75 ms startup query.
- **Minimal new dependency.** `libc` is already transitive, so promoting it to a direct dep adds zero bytes to the release binary.
- **Testability comes for free.** The previous implementation could only be exercised against a real terminal that doesn't reply to OSC 11 — untestable in CI. Factoring the read loop into a function generic over `Read + Write` lets the regression be reproduced deterministically with `UnixStream::pair()`.
- **No behavioural change on the happy path.** Terminals that reply to OSC 11 see exactly the same output — the function returns the same parsed RGB triple within the same 75 ms budget, and the rest of the `detect_theme` → `relaunch_with_theme` flow is untouched.

## Files changed

| File | Lines | Purpose |
|---|---|---|
| `src/term_query.rs` (new) | +190 | Helper + parsers + tests |
| `src/main.rs` | +16 / −68 | Use the helper; remove inline thread, read loop, and parsers |
| `Cargo.toml` | +4 | Unix-only `libc` dep |
| `src/lib.rs` | +1 | Expose `pub mod term_query` |

## Verification

- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: clean
- `cargo test`: 638 lib + 4 integration + 3 doctests pass, including the 8 new `term_query` tests
- Cross-compiled `aarch64-unknown-linux-gnu` release binary, deployed to a Raspberry Pi 4 running Debian 13, tested over SSH from iOS Termius — reporter confirms responsiveness is restored
