### PR TITLE
Add support for reading markdown from stdin (markless -)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "filedescriptor",
  "mio",
  "parking_lot",
  "rustix 1.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,11 @@ categories = ["command-line-utilities", "text-processing"]
 [dependencies]
 # TUI framework
 ratatui = "0.30"
-crossterm = "0.29"
+# `use-dev-tty` reads keyboard input from /dev/tty instead of stdin, which is
+# required for `markless -` (piped stdin) to work: with a pipe on stdin,
+# crossterm's default mio-based reader fails on macOS (kqueue can't register
+# the /dev/tty character device with EINVAL).
+crossterm = { version = "0.29", features = ["use-dev-tty"] }
 
 # Markdown parsing
 comrak = { version = "0.31", default-features = false, features = ["shortcodes"] }

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ echo "# Hello" | markless -
 printf '# Hello\n\nSome *markdown*' | markless -
 ```
 
-Piped input has no backing file, so watching, reloading, and editing are disabled (a toast explains each). Relative image paths in piped markdown resolve against the current working directory. Binary input is shown as a hex dump.
+Piped input has no backing file, so watching, reloading, and editing are disabled (a toast explains each). Relative image paths in piped markdown resolve against the current working directory. Binary input is shown as a hex dump. Piped content is always parsed as markdown — there's no filename or extension to trigger code-block wrapping for e.g. piped source code or CSV — so pipe markdown specifically. In stdin mode markless skips its terminal-capability query, so even with a real image protocol (kitty/sixel/iterm2), image scaling uses a fixed font size rather than the terminal's actual metrics and may be slightly misaligned.
 
 ## Command Line Options
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,19 @@ markless README.md          # View a file
 markless .                  # Browse current directory
 markless                    # Browse current directory (default)
 markless src/               # Browse a directory
+cat notes.md | markless -   # View markdown piped to stdin
 ```
 
 When given a directory, markless opens in browse mode: the sidebar shows the file listing and the first markdown file (or first file) is previewed automatically. Navigate with arrow keys, press Enter to open, and Backspace to go to the parent directory.
+
+When given `-` as the path, markless reads markdown from standard input:
+
+```bash
+echo "# Hello" | markless -
+printf '# Hello\n\nSome *markdown*' | markless -
+```
+
+Piped input has no backing file, so watching, reloading, and editing are disabled (a toast explains each). Relative image paths in piped markdown resolve against the current working directory. Binary input is shown as a hex dump.
 
 ## Command Line Options
 

--- a/src/app/effects.rs
+++ b/src/app/effects.rs
@@ -29,7 +29,9 @@ impl App {
     ) {
         match msg {
             Message::ToggleWatch => {
-                if model.watch_enabled {
+                if model.from_stdin {
+                    // update() already showed a warning; don't overwrite it.
+                } else if model.watch_enabled {
                     match Self::make_file_watcher(&model.file_path) {
                         Ok(watcher) => {
                             *file_watcher = Some(watcher);
@@ -54,7 +56,10 @@ impl App {
                 }
             }
             Message::ForceReload | Message::FileChanged => {
-                if model.editor_mode {
+                if model.from_stdin {
+                    // Piped input has no backing file to reload from.
+                    model.show_toast(ToastLevel::Warning, "Piped stdin input cannot be reloaded");
+                } else if model.editor_mode {
                     // Don't reload while editing — check for conflict instead
                     if let Some(new_hash) = model.file_disk_hash()
                         && model.editor_disk_hash != Some(new_hash)

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -1,4 +1,5 @@
-use std::io::{Write, stdout};
+use std::io::{IsTerminal, Write, stdout};
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -107,6 +108,24 @@ impl App {
     pub fn run(&mut self) -> Result<()> {
         let _run_scope = crate::perf::scope("app.run.total");
 
+        // Read piped stdin content BEFORE creating the image picker: the
+        // picker's terminal-capability query reads from stdin and would
+        // otherwise consume the piped markdown.
+        let stdin_source = if self.stdin_mode {
+            if std::io::stdin().is_terminal() {
+                anyhow::bail!(
+                    "markless - reads markdown from standard input.\n\
+                     Pipe input to it instead, e.g.:  echo \"# hello\" | markless -"
+                );
+            }
+            let mut buf = Vec::new();
+            std::io::Read::read_to_end(&mut std::io::stdin(), &mut buf)
+                .context("Failed to read markdown from stdin")?;
+            Some(buf)
+        } else {
+            None
+        };
+
         // Create image picker BEFORE initializing terminal (queries stdio)
         let picker = if self.images_enabled {
             let picker_scope = crate::perf::scope("app.create_picker");
@@ -151,7 +170,14 @@ impl App {
                 layout_width
             ),
         );
-        let (document, effective_file) = if let Some(ref file) = initial_file {
+        let (document, effective_file) = if let Some(bytes) = stdin_source {
+            let doc = crate::document::prepare_stdin_document(
+                bytes,
+                layout_width,
+                terminal_content_width,
+            );
+            (doc, self.file_path.clone())
+        } else if let Some(ref file) = initial_file {
             let raw_bytes = std::fs::read(file)?;
             let doc = crate::document::prepare_document_from_bytes_with_widths(
                 file,
@@ -169,7 +195,7 @@ impl App {
         // Create initial model
         let mut model =
             Model::new(effective_file, document, (size.width, size.height)).with_picker(picker);
-        model.watch_enabled = self.watch_enabled;
+        model.watch_enabled = self.watch_enabled && !self.stdin_mode;
         model.mouse_enabled = self.mouse_enabled;
         model.toc_visible = toc_visible;
         model.image_mode = self.image_mode;
@@ -199,6 +225,14 @@ impl App {
                     }
                 }
             }
+        }
+
+        // Piped input: no file to watch/edit/reload, and relative image
+        // paths resolve against the current working directory.
+        if self.stdin_mode {
+            model.from_stdin = true;
+            model.base_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            model.show_toast(ToastLevel::Info, "Reading markdown from stdin (pipe)");
         }
 
         // Reparse with mermaid-as-images now that the picker is configured.

--- a/src/app/event_loop.rs
+++ b/src/app/event_loop.rs
@@ -108,9 +108,11 @@ impl App {
     pub fn run(&mut self) -> Result<()> {
         let _run_scope = crate::perf::scope("app.run.total");
 
-        // Read piped stdin content BEFORE creating the image picker: the
-        // picker's terminal-capability query reads from stdin and would
-        // otherwise consume the piped markdown.
+        // Read piped stdin content early, before terminal/picker init, so the
+        // document is available up front. The image picker skips its stdio
+        // capability query entirely in stdin mode (query_stdio=false below):
+        // that query would otherwise consume/block on the pipe, and the
+        // terminal's response to it can't arrive through a piped stdin anyway.
         let stdin_source = if self.stdin_mode {
             if std::io::stdin().is_terminal() {
                 anyhow::bail!(
@@ -129,7 +131,7 @@ impl App {
         // Create image picker BEFORE initializing terminal (queries stdio)
         let picker = if self.images_enabled {
             let picker_scope = crate::perf::scope("app.create_picker");
-            let picker = crate::image::create_picker(self.image_mode);
+            let picker = crate::image::create_picker(self.image_mode, !self.stdin_mode);
             drop(picker_scope);
             picker
         } else {
@@ -232,7 +234,14 @@ impl App {
         if self.stdin_mode {
             model.from_stdin = true;
             model.base_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-            model.show_toast(ToastLevel::Info, "Reading markdown from stdin (pipe)");
+            if self.watch_enabled {
+                model.show_toast(
+                    ToastLevel::Info,
+                    "Reading markdown from stdin (pipe) — --watch is not supported for piped input",
+                );
+            } else {
+                model.show_toast(ToastLevel::Info, "Reading markdown from stdin (pipe)");
+            }
         }
 
         // Reparse with mermaid-as-images now that the picker is configured.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -33,6 +33,7 @@ pub struct App {
     wrap_width: Option<u16>,
     editor: Option<String>,
     no_inline_math: bool,
+    stdin_mode: bool,
 }
 
 impl App {
@@ -51,6 +52,7 @@ impl App {
             wrap_width: None,
             editor: None,
             no_inline_math: false,
+            stdin_mode: false,
         }
     }
 
@@ -126,6 +128,14 @@ impl App {
     ) -> Self {
         self.config_global_path = global_path;
         self.config_local_path = local_path;
+        self
+    }
+
+    /// Read the document from standard input instead of a file
+    /// (invoked as `markless -`).
+    #[must_use]
+    pub const fn with_stdin_mode(mut self, enabled: bool) -> Self {
+        self.stdin_mode = enabled;
         self
     }
 }

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -755,6 +755,9 @@ impl Model {
         let raw_bytes = std::fs::read(path)?;
         let document = self.document_from_bytes(path, raw_bytes)?;
         self.file_path = path.to_path_buf();
+        // A real on-disk file was just loaded, so it is no longer piped
+        // stdin input, even if the model started out in stdin mode.
+        self.from_stdin = false;
         self.base_dir = path
             .parent()
             .map_or_else(|| PathBuf::from("."), std::path::Path::to_path_buf);

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -166,6 +166,8 @@ pub struct Model {
     pub failed_math_srcs: HashSet<String>,
     /// Disable inline (Unicode) math, rendering as images instead.
     pub no_inline_math: bool,
+    /// Whether the document was read from a pipe (`markless -`).
+    pub from_stdin: bool,
 }
 
 impl std::fmt::Debug for Model {
@@ -243,6 +245,7 @@ impl Model {
             failed_mermaid_srcs: HashSet::new(),
             failed_math_srcs: HashSet::new(),
             no_inline_math: false,
+            from_stdin: false,
         }
     }
 
@@ -798,7 +801,9 @@ impl Model {
     /// the text-editable whitelist or is recognized by syntect, AND whose
     /// content is not binary (hex mode).  All other files are rejected.
     pub fn can_edit(&self) -> bool {
-        crate::document::is_editable_file(&self.file_path) && !self.document.is_hex_mode()
+        !self.from_stdin
+            && crate::document::is_editable_file(&self.file_path)
+            && !self.document.is_hex_mode()
     }
 
     /// Whether the editor has unsaved changes.
@@ -1106,6 +1111,7 @@ impl Default for Model {
             failed_mermaid_srcs: HashSet::new(),
             failed_math_srcs: HashSet::new(),
             no_inline_math: false,
+            from_stdin: false,
         }
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -150,6 +150,27 @@ fn test_stdin_model_base_dir_is_current_directory() {
 }
 
 #[test]
+fn test_load_file_clears_from_stdin_for_real_file() {
+    let dir = tempdir().unwrap();
+    let file_path = dir.path().join("doc.md");
+    std::fs::write(&file_path, "# Real\n\nfrom disk").unwrap();
+
+    let mut model = create_stdin_model();
+    assert!(model.from_stdin);
+
+    model.load_file(&file_path).unwrap();
+
+    assert!(
+        !model.from_stdin,
+        "loading a real file must clear the stdin flag"
+    );
+    assert!(
+        model.can_edit(),
+        "a real on-disk markdown file must be editable after load_file"
+    );
+}
+
+#[test]
 fn test_force_reload_reloads_document_from_disk() {
     let dir = tempdir().unwrap();
     let file_path = dir.path().join("doc.md");

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -90,6 +90,65 @@ fn test_toggle_watch_changes_state() {
     assert!(model.watch_enabled);
 }
 
+// --- Stdin pipe tests (`markless -`) ---
+
+fn create_stdin_model() -> Model {
+    let doc = Document::parse("# Piped\n\nContent from stdin").unwrap();
+    let mut model = Model::new(PathBuf::from("<stdin>"), doc, (80, 24));
+    model.from_stdin = true;
+    model.base_dir = PathBuf::from(".");
+    model
+}
+
+#[test]
+fn test_stdin_model_cannot_edit() {
+    let model = create_stdin_model();
+    assert!(
+        !model.can_edit(),
+        "piped input has no backing file and must not be editable"
+    );
+
+    let model = update(model, Message::EnterEditMode);
+    assert!(!model.editor_mode, "edit mode must not engage for stdin");
+    let (msg, level) = model.active_toast().expect("warning toast expected");
+    assert_eq!(level, ToastLevel::Warning);
+    assert!(
+        msg.contains("stdin"),
+        "toast should mention stdin, got: {msg}"
+    );
+}
+
+#[test]
+fn test_stdin_model_watch_is_off_and_cannot_be_toggled() {
+    let model = create_stdin_model();
+    assert!(
+        !model.watch_enabled,
+        "watching is meaningless for piped input"
+    );
+
+    let model = update(model, Message::ToggleWatch);
+    assert!(
+        !model.watch_enabled,
+        "watch must stay disabled for piped input"
+    );
+    let (msg, level) = model.active_toast().expect("warning toast expected");
+    assert_eq!(level, ToastLevel::Warning);
+    assert!(
+        msg.contains("stdin"),
+        "toast should mention stdin, got: {msg}"
+    );
+}
+
+#[test]
+fn test_stdin_model_base_dir_is_current_directory() {
+    let model = create_stdin_model();
+    assert_eq!(
+        model.base_dir,
+        PathBuf::from("."),
+        "relative image paths in piped markdown resolve against the cwd"
+    );
+}
+
 #[test]
 fn test_force_reload_reloads_document_from_disk() {
     let dir = tempdir().unwrap();

--- a/src/app/update.rs
+++ b/src/app/update.rs
@@ -304,7 +304,14 @@ pub fn update(mut model: Model, msg: Message) -> Model {
 
         // File watching
         Message::ToggleWatch => {
-            model.watch_enabled = !model.watch_enabled;
+            if model.from_stdin {
+                model.show_toast(
+                    crate::app::ToastLevel::Warning,
+                    "Cannot watch piped stdin input",
+                );
+            } else {
+                model.watch_enabled = !model.watch_enabled;
+            }
         }
         Message::ToggleHelp => {
             model.help_visible = !model.help_visible;
@@ -424,7 +431,9 @@ pub fn update(mut model: Model, msg: Message) -> Model {
         // Editor
         Message::EnterEditMode => {
             if !model.can_edit() {
-                let reason = if model.document.is_hex_mode() {
+                let reason = if model.from_stdin {
+                    "Cannot edit piped stdin input".to_string()
+                } else if model.document.is_hex_mode() {
                     "Cannot edit binary files".to_string()
                 } else {
                     let ext = model

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -284,6 +284,19 @@ pub fn prepare_document_from_bytes_with_widths(
     Document::from_hex(&name, bytes)
 }
 
+/// Build a [`Document`] from raw stdin bytes (`markless -`).
+///
+/// Text input is parsed as markdown. Binary input is displayed as a
+/// hex dump, mirroring how binary files are handled on disk.
+pub fn prepare_stdin_document(bytes: Vec<u8>, wrap_width: u16, max_width: u16) -> Document {
+    if !is_binary(&bytes) {
+        let content = String::from_utf8(bytes).unwrap_or_default();
+        return Document::parse_with_widths(&content, wrap_width, max_width)
+            .unwrap_or_else(|_| Document::empty());
+    }
+    Document::from_hex("<stdin>", bytes)
+}
+
 /// Returns true if the byte slice appears to be binary (non-text) content.
 ///
 /// Checks for null bytes and invalid UTF-8. Text files with valid UTF-8
@@ -560,6 +573,47 @@ mod tests {
         let bytes = &[0x01, 0x02, 0x7f, 0x80];
         let result = format_hex_dump(bytes);
         assert!(result.contains("|....|"));
+    }
+
+    #[test]
+    fn test_prepare_stdin_document_parses_markdown() {
+        let bytes = b"# Hello\n\nSome *content* with a [link](https://example.com)".to_vec();
+        let doc = prepare_stdin_document(bytes, 80, 120);
+        assert!(!doc.is_hex_mode());
+        // Heading should be extracted for the TOC
+        assert_eq!(doc.headings().len(), 1);
+        assert_eq!(doc.headings()[0].text, "Hello");
+        // Links should be detected
+        assert!(
+            doc.links().iter().any(|l| l.url == "https://example.com"),
+            "markdown links from stdin should be parsed"
+        );
+    }
+
+    #[test]
+    fn test_prepare_stdin_document_binary_uses_hex_dump() {
+        let bytes = vec![0x00, 0x01, 0x02, 0xff];
+        let doc = prepare_stdin_document(bytes, 80, 120);
+        assert!(doc.is_hex_mode());
+        // Header (4) + 1 hex line
+        assert_eq!(doc.line_count(), 5);
+        // Heading should label the source as stdin
+        let heading = doc.line_at(0).unwrap();
+        assert!(heading.content().contains("<stdin>"));
+    }
+
+    #[test]
+    fn test_prepare_stdin_document_empty_input() {
+        let doc = prepare_stdin_document(Vec::new(), 80, 120);
+        assert!(!doc.is_hex_mode());
+        assert!(doc.headings().is_empty());
+    }
+
+    #[test]
+    fn test_prepare_stdin_document_invalid_utf8_treated_as_binary() {
+        let bytes = vec![0xff, 0xfe, 0x00];
+        let doc = prepare_stdin_document(bytes, 80, 120);
+        assert!(doc.is_hex_mode());
     }
 
     #[test]

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -288,9 +288,14 @@ pub fn prepare_document_from_bytes_with_widths(
 ///
 /// Text input is parsed as markdown. Binary input is displayed as a
 /// hex dump, mirroring how binary files are handled on disk.
+///
+/// # Panics
+///
+/// Panics if `bytes` is not valid UTF-8 despite `is_binary()` reporting it as
+/// text; `is_binary()` is expected to guarantee this never happens.
 pub fn prepare_stdin_document(bytes: Vec<u8>, wrap_width: u16, max_width: u16) -> Document {
     if !is_binary(&bytes) {
-        let content = String::from_utf8(bytes).unwrap_or_default();
+        let content = String::from_utf8(bytes).expect("is_binary() already validated UTF-8");
         return Document::parse_with_widths(&content, wrap_width, max_width)
             .unwrap_or_else(|_| Document::empty());
     }

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -55,7 +55,60 @@ fn picker_with_protocol(protocol_type: ProtocolType, reason: &str) -> Picker {
 ///
 /// When `image_mode` is `Some`, the picker is forced to use that protocol.
 /// Otherwise, terminal capabilities are auto-detected.
-pub fn create_picker(image_mode: Option<ImageMode>) -> Option<Picker> {
+///
+/// When `query_stdio` is `false`, the terminal-capability stdio query is
+/// skipped entirely. This must be used whenever stdin is piped input (e.g.
+/// `markless -`): the query reads from stdin and would otherwise hang
+/// forever reading EOF from an already-consumed pipe, and the terminal's
+/// response to the query would arrive on `/dev/tty` rather than the piped
+/// stdin anyway, so the query could never succeed in that case.
+///
+/// Without the stdio query, `image_mode` is honored directly when `Some`,
+/// and when `None` the protocol is still auto-detected from environment
+/// variables (see [`detect_protocol`]) so that Kitty/iTerm2/WezTerm/Ghostty
+/// users piping markdown keep a real image protocol instead of always
+/// falling back to half-blocks. In all cases the returned picker uses the
+/// hardcoded half-blocks font size (10x20) rather than the terminal's real
+/// cell metrics, since that information can only come from the stdio query.
+/// This can cause image scaling misalignment for piped content with images
+/// even when a pixel protocol (kitty/sixel/iterm2) is in use.
+pub fn create_picker(image_mode: Option<ImageMode>, query_stdio: bool) -> Option<Picker> {
+    if !query_stdio {
+        let picker = image_mode.map_or_else(
+            || {
+                let detected = detect_protocol();
+                let mut picker = Picker::halfblocks();
+                if detected == ImageMode::Halfblock {
+                    crate::perf::log_event(
+                        "image.create_picker",
+                        "stdio query skipped protocol=Halfblocks",
+                    );
+                } else {
+                    let protocol_type = image_mode_to_protocol_type(detected);
+                    picker.set_protocol_type(protocol_type);
+                    crate::perf::log_event(
+                        "image.create_picker",
+                        format!("stdio query skipped env-detected protocol={protocol_type:?}"),
+                    );
+                }
+                picker
+            },
+            |mode| {
+                let protocol_type = image_mode_to_protocol_type(mode);
+                let mut picker = Picker::halfblocks();
+                if protocol_type != ProtocolType::Halfblocks {
+                    picker.set_protocol_type(protocol_type);
+                }
+                crate::perf::log_event(
+                    "image.create_picker",
+                    format!("stdio query skipped protocol={protocol_type:?}"),
+                );
+                picker
+            },
+        );
+        return Some(picker);
+    }
+
     if let Some(mode) = image_mode {
         let protocol_type = image_mode_to_protocol_type(mode);
         if protocol_type == ProtocolType::Halfblocks {
@@ -262,5 +315,56 @@ mod tests {
         let image = DynamicImage::ImageRgba8(RgbaImage::from_pixel(1, 1, Rgba([12, 34, 56, 77])));
         let quantized = quantize_to_ansi256(&image).to_rgba8();
         assert_eq!(quantized.get_pixel(0, 0)[3], 77);
+    }
+
+    // `create_picker(_, false)` never performs the stdio capability query, so
+    // the returned picker always uses the hardcoded half-blocks font size
+    // regardless of which protocol ends up selected.
+    #[test]
+    fn test_create_picker_no_query_stdio_uses_halfblocks_font_size() {
+        let picker = create_picker(None, false).expect("picker should be created");
+        assert_eq!(picker.font_size(), (10, 20));
+        // Auto-detect now consults `detect_protocol()`, which reads
+        // environment variables that vary by CI/test environment, so only
+        // assert the protocol is one of the known variants (env-independent).
+        assert!(matches!(
+            picker.protocol_type(),
+            ProtocolType::Halfblocks
+                | ProtocolType::Kitty
+                | ProtocolType::Sixel
+                | ProtocolType::Iterm2
+        ));
+    }
+
+    #[test]
+    fn test_create_picker_no_query_stdio_forced_kitty() {
+        let picker =
+            create_picker(Some(ImageMode::Kitty), false).expect("picker should be created");
+        assert_eq!(picker.protocol_type(), ProtocolType::Kitty);
+        assert_eq!(picker.font_size(), (10, 20));
+    }
+
+    #[test]
+    fn test_create_picker_no_query_stdio_forced_iterm2() {
+        let picker =
+            create_picker(Some(ImageMode::ITerm2), false).expect("picker should be created");
+        assert_eq!(picker.protocol_type(), ProtocolType::Iterm2);
+        assert_eq!(picker.font_size(), (10, 20));
+    }
+
+    #[test]
+    fn test_create_picker_no_query_stdio_forced_sixel() {
+        let picker =
+            create_picker(Some(ImageMode::Sixel), false).expect("picker should be created");
+        assert_eq!(picker.protocol_type(), ProtocolType::Sixel);
+        assert_eq!(picker.font_size(), (10, 20));
+    }
+
+    #[test]
+    fn test_create_picker_no_query_stdio_forced_halfblock() {
+        let picker =
+            create_picker(Some(ImageMode::Halfblock), false).expect("picker should be created");
+        assert_eq!(picker.protocol_type(), ProtocolType::Halfblocks);
+        assert_eq!(picker.font_size(), (10, 20));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use markless::term_query::{parse_osc11_reply, read_osc_response};
 #[derive(Parser, Debug)]
 #[command(name = "markless", version, about, long_about = None)]
 struct Cli {
-    /// Markdown file or directory to view
+    /// Markdown file, directory to browse, or `-` to read markdown from stdin
     #[arg(value_name = "PATH", default_value = ".")]
     path: PathBuf,
 
@@ -222,6 +222,19 @@ fn relaunch_with_theme(mode: HighlightBackground, raw_args: &[String]) -> Result
     Ok(())
 }
 
+/// Resolve the CLI path argument, mapping the stdin sentinel `-` to the
+/// pseudo-path `<stdin>` used throughout the app.
+///
+/// Returns the resolved path and whether the document should be read from
+/// standard input (`markless -`).
+fn resolve_path(path: PathBuf) -> (PathBuf, bool) {
+    if path == *"-" {
+        (PathBuf::from("<stdin>"), true)
+    } else {
+        (path, false)
+    }
+}
+
 fn main() -> Result<()> {
     // Restore terminal state on panic so the shell isn't left in raw mode
     let default_hook = std::panic::take_hook();
@@ -241,6 +254,7 @@ fn main() -> Result<()> {
 
     let raw_args = std::env::args().collect::<Vec<_>>();
     let cli = Cli::parse();
+    let (path, stdin_mode) = resolve_path(cli.path.clone());
     let global_path = global_config_path();
     let local_path = local_override_path();
     let cli_flags = parse_flag_tokens(&raw_args);
@@ -287,18 +301,19 @@ fn main() -> Result<()> {
         ThemeMode::Dark => set_background_mode(Some(HighlightBackground::Dark)),
     }
 
-    // Verify path exists
-    if !cli.path.exists() {
+    // Verify path exists (skipped for `markless -`, which reads stdin)
+    if !stdin_mode && !cli.path.exists() {
         anyhow::bail!("Path not found: {}", cli.path.display());
     }
 
-    let is_directory = cli.path.is_dir();
+    let is_directory = !stdin_mode && cli.path.is_dir();
 
     // Run the application
     // Normalize editor: empty string from --no-editor becomes None
     let editor = effective.editor.filter(|e| !e.is_empty());
 
-    let mut app = App::new(cli.path)
+    let mut app = App::new(path)
+        .with_stdin_mode(stdin_mode)
         .with_watch(effective.watch)
         .with_mouse_enabled(effective.mouse_select || !effective.no_mouse_select)
         .with_toc_visible(effective.toc && !effective.no_toc)
@@ -318,4 +333,43 @@ fn main() -> Result<()> {
         );
 
     app.run().context("Application error")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn dash_path_resolves_to_stdin_mode() {
+        let (path, stdin_mode) = resolve_path(PathBuf::from("-"));
+        assert!(stdin_mode, "`-` should enable stdin mode");
+        assert_eq!(path, PathBuf::from("<stdin>"));
+    }
+
+    #[test]
+    fn ordinary_path_is_not_stdin_mode() {
+        let (path, stdin_mode) = resolve_path(PathBuf::from("README.md"));
+        assert!(!stdin_mode);
+        assert_eq!(path, PathBuf::from("README.md"));
+    }
+
+    #[test]
+    fn default_path_is_current_directory() {
+        let cli = Cli::try_parse_from(["markless"]).unwrap();
+        assert_eq!(cli.path, PathBuf::from("."));
+    }
+
+    #[test]
+    fn cli_accepts_dash_as_path() {
+        let cli = Cli::try_parse_from(["markless", "-"]).unwrap();
+        assert_eq!(cli.path, PathBuf::from("-"));
+    }
+
+    #[test]
+    fn cli_accepts_flags_with_dash_path() {
+        let cli = Cli::try_parse_from(["markless", "--no-toc", "-"]).unwrap();
+        assert!(cli.no_toc);
+        assert_eq!(cli.path, PathBuf::from("-"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@
 //! markless --no-toc README.md
 //! ```
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
@@ -228,7 +228,7 @@ fn relaunch_with_theme(mode: HighlightBackground, raw_args: &[String]) -> Result
 /// Returns the resolved path and whether the document should be read from
 /// standard input (`markless -`).
 fn resolve_path(path: PathBuf) -> (PathBuf, bool) {
-    if path == *"-" {
+    if path == Path::new("-") {
         (PathBuf::from("<stdin>"), true)
     } else {
         (path, false)


### PR DESCRIPTION
## Summary

Adds support for piping markdown into markless via a single dash argument:

```bash
echo "# hello" | markless -
cat notes.md | markless - --toc
```

## What changed

- **CLI**: `-` maps to a pseudo `<stdin>` path; skips path-exists check and browse mode. The piped document is read in `App::run` before the image picker and after theme relaunch (so the pipe survives `exec` on theme re-launch).
- **Rendering**: piped text is parsed as markdown; binary input is shown as a hex dump. Relative image paths resolve against the current working directory.
- **Guards**: piped input has no backing file, so editing, watching, and reloading are disabled with explanatory toasts; the flag is cleared once a real file is loaded (e.g. browsing out of a pipe session).
- **crossterm `use-dev-tty`**: required for piped stdin to work on macOS — the default mio/kqueue event reader cannot register `/dev/tty` (EINVAL) when stdin is a pipe, so keyboard input failed. Reading events from `/dev/tty` (like `less`) also fixes `markless FILE` with redirected stdin.
- **Picker**: the image picker's stdio capability query is skipped in stdin mode (`create_picker(…, query_stdio)`), since it would hang on an EOF'd pipe (Linux) and can never succeed through a pipe anyway; protocol is auto-detected from env vars instead. Documented 10×20 fixed-font-size tradeoff for piped pixel-protocol images.
- **Docs & tests**: README usage; unit tests for CLI path resolution, stdin document preparation (markdown/binary/empty/invalid-UTF-8), model guards, `load_file` clearing `from_stdin`, and the picker no-query paths. 663 tests pass; `cargo fmt` clean; no new clippy warnings.

## Notes

- `markless -` with a TTY on stdin prints a friendly hint instead of hanging.
- Piped content is always parsed as markdown (no filename/extension to trigger code-block wrapping).